### PR TITLE
Add handling for max sensor range and NaN/inf points

### DIFF
--- a/example/pointcloud_voxelization.cpp
+++ b/example/pointcloud_voxelization.cpp
@@ -1,5 +1,6 @@
 #include <cstring>
 #include <functional>
+#include <limits>
 #include <vector>
 
 #include <Eigen/Geometry>
@@ -36,6 +37,11 @@ public:
   void PushBack(const Eigen::Vector3d& point)
   {
     points_.push_back(point);
+  }
+
+  double MaxRange() const override
+  {
+    return std::numeric_limits<double>::infinity();
   }
 
   int64_t Size() const override { return static_cast<int64_t>(points_.size()); }

--- a/include/voxelized_geometry_tools/cuda_voxelization_helpers.h
+++ b/include/voxelized_geometry_tools/cuda_voxelization_helpers.h
@@ -23,7 +23,7 @@ public:
 
   virtual void RaycastPoints(
       const std::vector<float>& raw_points,
-      const float* const pointcloud_origin_transform,
+      const float* const pointcloud_origin_transform, const float max_range,
       const float* const inverse_grid_origin_transform,
       const float inverse_step_size, const float inverse_cell_size,
       const int32_t num_x_cells, const int32_t num_y_cells,

--- a/include/voxelized_geometry_tools/opencl_voxelization_helpers.h
+++ b/include/voxelized_geometry_tools/opencl_voxelization_helpers.h
@@ -26,6 +26,7 @@ public:
   virtual void RaycastPoints(
       const std::vector<float>& raw_points,
       const Eigen::Isometry3f& pointcloud_origin_transform,
+      const float max_range,
       const Eigen::Isometry3f& inverse_grid_origin_transform,
       const float inverse_step_size, const float inverse_cell_size,
       const int32_t num_x_cells, const int32_t num_y_cells,

--- a/include/voxelized_geometry_tools/pointcloud_voxelization_interface.hpp
+++ b/include/voxelized_geometry_tools/pointcloud_voxelization_interface.hpp
@@ -96,6 +96,8 @@ public:
 
   virtual ~PointCloudWrapper() {}
 
+  virtual double MaxRange() const = 0;
+
   virtual int64_t Size() const = 0;
 
   virtual const Eigen::Isometry3d& GetPointCloudOriginTransform() const = 0;
@@ -187,6 +189,7 @@ protected:
   virtual void CopyPointLocationIntoFloatPtrImpl(
       const int64_t point_index, float* destination) const = 0;
 };
+
 using PointCloudWrapperPtr = std::shared_ptr<PointCloudWrapper>;
 
 class VoxelizerRuntime

--- a/include/voxelized_geometry_tools/pointcloud_voxelization_ros_interface.hpp
+++ b/include/voxelized_geometry_tools/pointcloud_voxelization_ros_interface.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstring>
+#include <limits>
 #include <map>
 #include <stdexcept>
 #include <vector>
@@ -17,6 +18,8 @@ class PointCloud2Wrapper : public PointCloudWrapper
 {
 public:
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  double MaxRange() const override { return max_range_; }
 
   int64_t Size() const override
   {
@@ -37,7 +40,7 @@ public:
 protected:
   PointCloud2Wrapper(
       const sensor_msgs::PointCloud2* const cloud_ptr,
-      const Eigen::Isometry3d& origin_transform);
+      const Eigen::Isometry3d& origin_transform, const double max_range);
 
 private:
   void CopyPointLocationIntoDoublePtrImpl(
@@ -68,6 +71,7 @@ private:
   const sensor_msgs::PointCloud2* const cloud_ptr_ = nullptr;
   size_t xyz_offset_from_point_start_ = 0;
   Eigen::Isometry3d origin_transform_ = Eigen::Isometry3d::Identity();
+  double max_range_ = std::numeric_limits<double>::infinity();
 };
 
 class NonOwningPointCloud2Wrapper : public PointCloud2Wrapper
@@ -77,8 +81,9 @@ public:
 
   NonOwningPointCloud2Wrapper(
       const sensor_msgs::PointCloud2* const cloud_ptr,
-      const Eigen::Isometry3d& origin_transform)
-      : PointCloud2Wrapper(cloud_ptr, origin_transform) {}
+      const Eigen::Isometry3d& origin_transform,
+      const double max_range = std::numeric_limits<double>::infinity())
+      : PointCloud2Wrapper(cloud_ptr, origin_transform, max_range) {}
 };
 
 class OwningPointCloud2Wrapper : public PointCloud2Wrapper
@@ -88,8 +93,9 @@ public:
 
   OwningPointCloud2Wrapper(
       const sensor_msgs::PointCloud2ConstPtr& cloud_ptr,
-      const Eigen::Isometry3d& origin_transform)
-      : PointCloud2Wrapper(cloud_ptr.get(), origin_transform),
+      const Eigen::Isometry3d& origin_transform,
+      const double max_range = std::numeric_limits<double>::infinity())
+      : PointCloud2Wrapper(cloud_ptr.get(), origin_transform, max_range),
         owned_cloud_ptr_(cloud_ptr) {}
 
 private:

--- a/src/voxelized_geometry_tools/cuda_pointcloud_voxelization.cpp
+++ b/src/voxelized_geometry_tools/cuda_pointcloud_voxelization.cpp
@@ -71,6 +71,7 @@ VoxelizerRuntime CudaPointCloudVoxelizer::DoVoxelizePointClouds(
       const PointCloudWrapperPtr& pointcloud = pointclouds.at(idx);
       const Eigen::Isometry3f pointcloud_origin_transform_float =
           pointcloud->GetPointCloudOriginTransform().cast<float>();
+      const float max_range = static_cast<float>(pointcloud->MaxRange());
       // Copy pointcloud
       std::vector<float> raw_points(pointcloud->Size() * 3, 0.0);
       for (int64_t point = 0; point < pointcloud->Size(); point++)
@@ -80,7 +81,7 @@ VoxelizerRuntime CudaPointCloudVoxelizer::DoVoxelizePointClouds(
       }
       // Raycast
       interface_->RaycastPoints(
-          raw_points, pointcloud_origin_transform_float.data(),
+          raw_points, pointcloud_origin_transform_float.data(), max_range,
           inverse_grid_origin_transform_float.data(), inverse_step_size,
           inverse_cell_size, num_x_cells, num_y_cells, num_z_cells,
           device_tracking_grid_offsets.at(idx));

--- a/src/voxelized_geometry_tools/dummy_cuda_voxelization_helpers.cc
+++ b/src/voxelized_geometry_tools/dummy_cuda_voxelization_helpers.cc
@@ -24,9 +24,9 @@ public:
   }
 
   void RaycastPoints(
-      const std::vector<float>&, const float* const, const float * const,
-      const float, const float, const int32_t, const int32_t, const int32_t,
-      const int64_t) override {}
+      const std::vector<float>&, const float* const, const float,
+      const float * const, const float, const float, const int32_t,
+      const int32_t, const int32_t, const int64_t) override {}
 
   void PrepareFilterGrid(const int64_t, const void*) override {}
 

--- a/src/voxelized_geometry_tools/dummy_opencl_voxelization_helpers.cc
+++ b/src/voxelized_geometry_tools/dummy_opencl_voxelization_helpers.cc
@@ -26,7 +26,7 @@ public:
   }
 
   void RaycastPoints(
-      const std::vector<float>&, const Eigen::Isometry3f&,
+      const std::vector<float>&, const Eigen::Isometry3f&, const float,
       const Eigen::Isometry3f&, const float, const float, const int32_t,
       const int32_t, const int32_t, const int64_t) override {}
 

--- a/src/voxelized_geometry_tools/opencl_pointcloud_voxelization.cpp
+++ b/src/voxelized_geometry_tools/opencl_pointcloud_voxelization.cpp
@@ -70,6 +70,7 @@ VoxelizerRuntime OpenCLPointCloudVoxelizer::DoVoxelizePointClouds(
       const PointCloudWrapperPtr& pointcloud = pointclouds.at(idx);
       const Eigen::Isometry3f pointcloud_origin_transform_float =
           pointcloud->GetPointCloudOriginTransform().cast<float>();
+      const float max_range = static_cast<float>(pointcloud->MaxRange());
       // Copy pointcloud
       std::vector<float> raw_points(pointcloud->Size() * 3, 0.0);
       for (int64_t point = 0; point < pointcloud->Size(); point++)
@@ -79,7 +80,7 @@ VoxelizerRuntime OpenCLPointCloudVoxelizer::DoVoxelizePointClouds(
       }
       // Raycast
       interface_->RaycastPoints(
-          raw_points, pointcloud_origin_transform_float,
+          raw_points, pointcloud_origin_transform_float, max_range,
           inverse_grid_origin_transform_float, inverse_step_size,
           inverse_cell_size, num_x_cells, num_y_cells, num_z_cells,
           device_tracking_grid_offsets.at(idx));

--- a/src/voxelized_geometry_tools/pointcloud_voxelization_ros_interface.cpp
+++ b/src/voxelized_geometry_tools/pointcloud_voxelization_ros_interface.cpp
@@ -15,12 +15,17 @@ namespace pointcloud_voxelization
 {
 PointCloud2Wrapper::PointCloud2Wrapper(
     const sensor_msgs::PointCloud2* const cloud_ptr,
-    const Eigen::Isometry3d& origin_transform)
-    : cloud_ptr_(cloud_ptr), origin_transform_(origin_transform)
+    const Eigen::Isometry3d& origin_transform, const double max_range)
+    : cloud_ptr_(cloud_ptr), origin_transform_(origin_transform),
+      max_range_(max_range)
 {
   if (cloud_ptr_ == nullptr)
   {
     throw std::invalid_argument("cloud_ptr_ == nullptr");
+  }
+  if (max_range_ <= 0.0)
+  {
+    throw std::runtime_error("max_range_ <= 0.0");
   }
   // Figure out what the size and offset for XYZ fields in the pointcloud are.
   std::map<std::string, uint8_t> field_type_map;


### PR DESCRIPTION
Adds several new features:

- Filters out invalid points marked with NaN or inf, so these points do not need to be removed from the pointcloud first.
- Adds per-pointcloud "max range", such that points will only be raycast up to max range, and points beyond max range will *not* be marked filled. This is intended to properly handle out-of-range points without introducing false obstacles - returning a point beyond max range will be interpreted that the camera saw clearly through max range and that the entire ray from camera origin to max range should be marked free.