### PR TITLE
Move OpenCL cl.hpp header to allow easier redistribution

### DIFF
--- a/CMakeLists.txt.ros1
+++ b/CMakeLists.txt.ros1
@@ -134,7 +134,7 @@ endif()
 # OpenCL voxelization helpers library
 if(OpenCL_FOUND)
     message(STATUS "OpenCL found. Building OpenCL voxelization helpers")
-    include_directories(SYSTEM opencl_cpp ${OpenCL_INCLUDE_DIRS})
+    include_directories(SYSTEM ${OpenCL_INCLUDE_DIRS})
     add_library(${PROJECT_NAME}_opencl_voxelization_helpers
                 include/${PROJECT_NAME}/device_voxelization_interface.hpp
                 include/${PROJECT_NAME}/opencl_voxelization_helpers.h

--- a/CMakeLists.txt.ros2
+++ b/CMakeLists.txt.ros2
@@ -107,7 +107,7 @@ endif()
 # OpenCL voxelization helpers library
 if(OpenCL_FOUND)
     message(STATUS "OpenCL found. Building OpenCL voxelization helpers")
-    include_directories(SYSTEM opencl_cpp ${OpenCL_INCLUDE_DIRS})
+    include_directories(SYSTEM ${OpenCL_INCLUDE_DIRS})
     add_library(${PROJECT_NAME}_opencl_voxelization_helpers
                 include/${PROJECT_NAME}/device_voxelization_interface.hpp
                 include/${PROJECT_NAME}/opencl_voxelization_helpers.h

--- a/LICENSE
+++ b/LICENSE
@@ -3,8 +3,8 @@ BSD 3-Clause License
 Copyright (c) 2018,
 Portions Calder Phillips-Grafflin, Worcester Polytechnic Institute,
 The University of Michigan, and Toyota Research Institute. The included copy of
-the OpenCL C++ bindings in opencl_cpp/cl.hpp is covered by the permissive OpenCL
-license; see the license header in that file for details.
+the OpenCL C++ bindings in include/voxelized_geometry_tools/cl.hpp is covered by
+the permissive OpenCL license; see the license header in that file for details.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/include/voxelized_geometry_tools/cl.hpp
+++ b/include/voxelized_geometry_tools/cl.hpp
@@ -1,3 +1,12 @@
+// Modifications to suppress warnings from this file.
+#if defined(__clang__)
+  /* Clang/LLVM */
+  #pragma clang system_header
+#elif defined(__GNUC__) || defined(__GNUG__)
+  /* GNU GCC/G++ */
+  #pragma GCC system_header
+#endif
+
 /*******************************************************************************
  * Copyright (c) 2008-2015 The Khronos Group Inc.
  *

--- a/src/voxelized_geometry_tools/opencl_voxelization_helpers.cc
+++ b/src/voxelized_geometry_tools/opencl_voxelization_helpers.cc
@@ -9,7 +9,7 @@
 #include <vector>
 
 #include <Eigen/Geometry>
-#include "cl.hpp"
+#include <voxelized_geometry_tools/cl.hpp>
 
 namespace voxelized_geometry_tools
 {


### PR DESCRIPTION
Moves `cl.hpp` from its own directory to the normal include path to allow easier redistribution via catkin/ament and adds compiler-specific pragmas to suppress warnings from it.