### PR TITLE
Define OpenCL target version

### DIFF
--- a/include/voxelized_geometry_tools/cl.hpp
+++ b/include/voxelized_geometry_tools/cl.hpp
@@ -7,6 +7,10 @@
   #pragma GCC system_header
 #endif
 
+// Modification to select OpenCL 1.2, which is the greatest-common-version
+// supported by these OpenCL bindings and Intel, Nvidia, AMD, and Apple drivers.
+#define CL_TARGET_OPENCL_VERSION 120
+
 /*******************************************************************************
  * Copyright (c) 2008-2015 The Khronos Group Inc.
  *


### PR DESCRIPTION
Leaving `CL_TARGET_OPENCL_VERSION` unset produces a warning from `/usr/include/CL/cl_version.h` on Ubuntu Focal. Since the vendored copy of `cl.hpp` here is also consumed by other projects using VGT, defining the target version directly in `cl.hpp` is the easiest way to ensure a consistent OpenCL version is targeted.

cc @jwnimmer-tri @IanTheEngineer