### PR TITLE
Restructure SignedDistanceField to template on scalar type

### DIFF
--- a/CMakeLists.txt.ros1
+++ b/CMakeLists.txt.ros1
@@ -104,6 +104,8 @@ add_library(${PROJECT_NAME}
             src/${PROJECT_NAME}/collision_map.cpp
             src/${PROJECT_NAME}/mesh_rasterizer.cpp
             src/${PROJECT_NAME}/dynamic_spatial_hashed_collision_map.cpp
+            src/${PROJECT_NAME}/signed_distance_field.cpp
+            src/${PROJECT_NAME}/signed_distance_field_generation.cpp
             src/${PROJECT_NAME}/tagged_object_collision_map.cpp)
 add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})

--- a/CMakeLists.txt.ros2
+++ b/CMakeLists.txt.ros2
@@ -78,6 +78,8 @@ add_library(${PROJECT_NAME}
             src/${PROJECT_NAME}/collision_map.cpp
             src/${PROJECT_NAME}/mesh_rasterizer.cpp
             src/${PROJECT_NAME}/dynamic_spatial_hashed_collision_map.cpp
+            src/${PROJECT_NAME}/signed_distance_field.cpp
+            src/${PROJECT_NAME}/signed_distance_field_generation.cpp
             src/${PROJECT_NAME}/tagged_object_collision_map.cpp)
 ament_target_dependencies(${PROJECT_NAME} common_robotics_utilities)
 

--- a/example/estimate_distance.cpp
+++ b/example/estimate_distance.cpp
@@ -62,7 +62,7 @@ void test_estimate_distance(
   const ColorRGBA free_color = common_robotics_utilities::color_builder::MakeFromFloatColors<ColorRGBA>(0.0, 0.0, 0.0, 0.0);
   const ColorRGBA unknown_color = common_robotics_utilities::color_builder::MakeFromFloatColors<ColorRGBA>(0.0, 0.0, 0.0, 0.0);
   const auto map_marker = voxelized_geometry_tools::ros_interface::ExportForDisplay(map, collision_color, free_color, unknown_color);
-  const auto sdf = map.ExtractSignedDistanceField(1e6, true, false, false).DistanceField();
+  const auto sdf = map.ExtractSignedDistanceFieldFloat(1e6, true, false, false).DistanceField();
   const auto sdf_marker = voxelized_geometry_tools::ros_interface::ExportSDFForDisplay(sdf, 0.05f);
   // Assemble a visualization_markers::Marker representation of the SDF to display in RViz
   Marker distance_rep;

--- a/example/spatial_segments.cpp
+++ b/example/spatial_segments.cpp
@@ -105,14 +105,14 @@ void test_spatial_segments(
     }
   }
   const auto sdf_result
-      = tocmap.ExtractSignedDistanceField(std::vector<uint32_t>(), std::numeric_limits<float>::infinity(), true, false, false);
+      = tocmap.ExtractSignedDistanceFieldFloat(std::vector<uint32_t>(), std::numeric_limits<float>::infinity(), true, false, false);
   const auto& sdf = sdf_result.DistanceField();
   Marker sdf_marker = voxelized_geometry_tools::ros_interface::ExportSDFForDisplay(sdf, 1.0f);
   sdf_marker.id = 1;
   sdf_marker.ns = "environment_sdf_no_border";
   display_markers.markers.push_back(sdf_marker);
   const auto virtual_border_sdf_result
-      = tocmap.ExtractSignedDistanceField(std::vector<uint32_t>(), std::numeric_limits<float>::infinity(), true, false, true);
+      = tocmap.ExtractSignedDistanceFieldFloat(std::vector<uint32_t>(), std::numeric_limits<float>::infinity(), true, false, true);
   const auto& virtual_border_sdf = virtual_border_sdf_result.DistanceField();
   Marker virtual_border_sdf_marker = voxelized_geometry_tools::ros_interface::ExportSDFForDisplay(virtual_border_sdf, 1.0f);
   virtual_border_sdf_marker.id = 1;

--- a/example/tutorial.cpp
+++ b/example/tutorial.cpp
@@ -20,172 +20,228 @@
 int main(int argc, char** argv)
 {
 #if VOXELIZED_GEOMETRY_TOOLS__SUPPORTED_ROS_VERSION == 2
-    using ColorRGBA = std_msgs::msg::ColorRGBA;
-    using Marker = visualization_msgs::msg::Marker;
+  using ColorRGBA = std_msgs::msg::ColorRGBA;
+  using Marker = visualization_msgs::msg::Marker;
 
-    rclcpp::init(argc, argv);
-    auto node = std::make_shared<rclcpp::Node>("sdf_tools_tutorial");
-    auto visualization_pub = node->create_publisher<Marker>(
-        "sdf_tools_tutorial_visualization", rclcpp::QoS(1).transient_local());
-    const std::function<void(const Marker&)> display_fn
-      = [&] (const Marker& marker)
-    {
-      visualization_pub->publish(marker);
-    };
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<rclcpp::Node>("sdf_tools_tutorial");
+  auto visualization_pub = node->create_publisher<Marker>(
+      "sdf_tools_tutorial_visualization", rclcpp::QoS(1).transient_local());
+  const std::function<void(const Marker&)> display_fn
+    = [&] (const Marker& marker)
+  {
+    visualization_pub->publish(marker);
+  };
 #elif VOXELIZED_GEOMETRY_TOOLS__SUPPORTED_ROS_VERSION == 1
-    using ColorRGBA = std_msgs::ColorRGBA;
-    using Marker = visualization_msgs::Marker;
+  using ColorRGBA = std_msgs::ColorRGBA;
+  using Marker = visualization_msgs::Marker;
 
-    // Make a ROS node, which we'll use to publish copies of the data in the CollisionMap and SDF
-    // and Rviz markers that allow us to visualize them.
-    ros::init(argc, argv, "sdf_tools_tutorial");
-    // Get a handle to the current node
-    ros::NodeHandle nh;
-    // Make a publisher for visualization messages
-    ros::Publisher visualization_pub = nh.advertise<Marker>(
-        "sdf_tools_tutorial_visualization", 1, true);
-    const std::function<void(const Marker&)> display_fn
-      = [&] (const Marker& marker)
-    {
-      visualization_pub.publish(marker);
-    };
+  // Make a ROS node, which we'll use to publish copies of the data in the
+  // CollisionMap and SDF and Rviz markers that allow us to visualize them.
+  ros::init(argc, argv, "sdf_tools_tutorial");
+  // Get a handle to the current node
+  ros::NodeHandle nh;
+  // Make a publisher for visualization messages
+  ros::Publisher visualization_pub = nh.advertise<Marker>(
+      "sdf_tools_tutorial_visualization", 1, true);
+  const std::function<void(const Marker&)> display_fn
+    = [&] (const Marker& marker)
+  {
+    visualization_pub.publish(marker);
+  };
 #endif
-    // In preparation, we want to set a couple common paramters
-    const double resolution = 0.25;
-    const double x_size = 10.0;
-    const double y_size = 10.0;
-    const double z_size = 10.0;
-    const common_robotics_utilities::voxel_grid::GridSizes grid_sizes(resolution, x_size, y_size, z_size);
-    // Let's center the grid around the origin
-    const Eigen::Translation3d origin_translation(-5.0, -5.0, -5.0);
-    const Eigen::Quaterniond origin_rotation(1.0, 0.0, 0.0, 0.0);
-    const Eigen::Isometry3d origin_transform = origin_translation * origin_rotation;
-    const std::string frame = "tutorial_frame";
-    ///////////////////////////////////
-    //// Let's make a CollisionMap ////
-    ///////////////////////////////////
-    // We pick a reasonable default and out-of-bounds value
-    // WE initialize it like this - the component value is automatically set to 0
-    const voxelized_geometry_tools::CollisionCell default_cell(0.0);
-    // First, let's make the container
-    voxelized_geometry_tools::CollisionMap collision_map(origin_transform, frame, grid_sizes, default_cell);
-    // Let's set some values
-    // This is how you should iterate through the 3D grid's cells
-    for (int64_t x_index = 0; x_index < collision_map.GetNumXCells(); x_index++)
+
+  // In preparation, we want to set a couple common paramters
+  const double resolution = 0.25;
+  const double x_size = 10.0;
+  const double y_size = 10.0;
+  const double z_size = 10.0;
+  const common_robotics_utilities::voxel_grid::GridSizes grid_sizes(
+      resolution, x_size, y_size, z_size);
+  // Let's center the grid around the origin
+  const Eigen::Translation3d origin_translation(-5.0, -5.0, -5.0);
+  const Eigen::Quaterniond origin_rotation(1.0, 0.0, 0.0, 0.0);
+  const Eigen::Isometry3d origin_transform =
+      origin_translation * origin_rotation;
+  const std::string frame = "tutorial_frame";
+
+  ///////////////////////////////////
+  //// Let's make a CollisionMap ////
+  ///////////////////////////////////
+
+  // We pick a reasonable default and out-of-bounds value
+  // By initializing like this, the component value is automatically set to 0.
+  const voxelized_geometry_tools::CollisionCell default_cell(0.0);
+  // First, let's make the container
+  voxelized_geometry_tools::CollisionMap collision_map(
+      origin_transform, frame, grid_sizes, default_cell);
+
+  // Let's set some values
+  // This is how you should iterate through the 3D grid's cells
+  for (int64_t x_index = 0; x_index < collision_map.GetNumXCells(); x_index++)
+  {
+    for (int64_t y_index = 0; y_index < collision_map.GetNumYCells(); y_index++)
     {
-        for (int64_t y_index = 0; y_index < collision_map.GetNumYCells(); y_index++)
+      for (int64_t z_index = 0; z_index < collision_map.GetNumZCells();
+           z_index++)
+      {
+        // Let's make the bottom corner (low x, low y, low z) an object
+        if ((x_index < (collision_map.GetNumXCells() / 2)) &&
+            (y_index < (collision_map.GetNumYCells() / 2)) &&
+            (z_index < (collision_map.GetNumZCells() / 2)))
         {
-            for (int64_t z_index = 0; z_index < collision_map.GetNumZCells(); z_index++)
-            {
-                // Let's make the bottom corner (low x, low y, low z) an object
-                if ((x_index < (collision_map.GetNumXCells() / 2)) && (y_index < (collision_map.GetNumYCells() / 2)) && (z_index < (collision_map.GetNumZCells() / 2)))
-                {
-                    const voxelized_geometry_tools::CollisionCell obstacle_cell(1.0); // Occupancy values > 0.5 are obstacles
-                    collision_map.SetValue(x_index, y_index, z_index, obstacle_cell);
-                }
-            }
+          // Occupancy values > 0.5 are obstacles
+          const voxelized_geometry_tools::CollisionCell obstacle_cell(1.0);
+          collision_map.SetValue(x_index, y_index, z_index, obstacle_cell);
         }
+      }
     }
-    // We can also set by location
-    const voxelized_geometry_tools::CollisionCell obstacle_cell(1.0); // Occupancy values > 0.5 are obstacles
-    collision_map.SetValue(0.0, 0.0, 0.0, obstacle_cell);
-    // Let's get some values
-    // We can query by index
-    int64_t x_index = 10;
-    int64_t y_index = 10;
-    int64_t z_index = 10;
-    const auto index_query = collision_map.GetImmutable(x_index, y_index, z_index);
-    // Is it in the grid?
-    if (index_query)
-    {
-      std::cout << "Index query result - stored value " << index_query.Value().Occupancy() << " (occupancy) " << index_query.Value().Component() << " (component)" << std::endl;
-    }
-    // Or we can query by location
-    double x_location = 0.0;
-    double y_location = 0.0;
-    double z_location = 0.0;
-    const auto location_query = collision_map.GetImmutable(x_location, y_location, z_location);
-    // Is it in the grid?
-    if (location_query)
-    {
-      std::cout << "Location query result - stored value " << location_query.Value().Occupancy() << " (occupancy) " << location_query.Value().Component() << " (component)" << std::endl;
-    }
-    // Let's compute connected components
-    const uint32_t num_connected_components = collision_map.UpdateConnectedComponents();
-    std::cout << " There are " << num_connected_components << " connected components in the grid" << std::endl;
-    // Let's display the results to Rviz
-    // First, the CollisionMap itself
-    // We need to provide colors to use
-    ColorRGBA collision_color;
-    collision_color.r = 1.0;
-    collision_color.g = 0.0;
-    collision_color.b = 0.0;
-    collision_color.a = 0.5;
-    ColorRGBA free_color;
-    free_color.r = 0.0;
-    free_color.g = 1.0;
-    free_color.b = 0.0;
-    free_color.a = 0.5;
-    ColorRGBA unknown_color;
-    unknown_color.r = 1.0;
-    unknown_color.g = 1.0;
-    unknown_color.b = 0.0;
-    unknown_color.a = 0.5;
-    Marker collision_map_marker = voxelized_geometry_tools::ros_interface::ExportForDisplay(collision_map, collision_color, free_color, unknown_color);
-    // To be safe, you'll need to set these yourself. The namespace (ns) value should distinguish between different things being displayed
-    // while the id value lets you have multiple versions of the same message at once. Always set this to 1 if you only want one copy.
-    collision_map_marker.ns = "collision_map";
-    collision_map_marker.id = 1;
-    // Send it off for display
-    display_fn(collision_map_marker);
-    // Now, let's draw the connected components
-    Marker connected_components_marker = voxelized_geometry_tools::ros_interface::ExportConnectedComponentsForDisplay(collision_map, false); // Generally, you don't want a special color for unknown [P(occupancy) = 0.5] components
-    connected_components_marker.ns = "connected_components";
-    connected_components_marker.id = 1;
-    display_fn(connected_components_marker);
-    ///////////////////////////
-    //// Let's make an SDF ////
-    ///////////////////////////
-    // We pick a reasonable out-of-bounds value
-    const float oob_value = std::numeric_limits<float>::infinity();
-    // We start by extracting the SDF from the CollisionMap
-    const auto sdf_with_extrema = collision_map.ExtractSignedDistanceField(oob_value, true, false, false);
-    const voxelized_geometry_tools::SignedDistanceField<std::vector<float>>& sdf = sdf_with_extrema.DistanceField();
-    std::cout << "Maximum distance in the SDF: " << sdf_with_extrema.Maximum() << ", minimum distance in the SDF: " << sdf_with_extrema.Minimum() << std::endl;
-    // Let's get some values
-    const auto index_sdf_query = sdf.GetImmutable(x_index, y_index, z_index);
-    // Is it in the grid?
-    if (index_sdf_query)
-    {
-      std::cout << "Index query result - stored distance " << index_sdf_query.Value() << std::endl;
-    }
-    const auto location_sdf_query = sdf.GetImmutable(x_location, y_location, z_location);
-    if (location_sdf_query)
-    {
-      std::cout << "Location query result - stored distance " << location_sdf_query.Value() << std::endl;
-    }
-    // Let's get some gradients
-    const auto index_gradient_query = sdf.GetCoarseGradient(x_index, y_index, z_index, true); // Usually, you want to enable 'edge gradients' i.e. gradients for cells on the edge of the grid that don't have 6 neighbors
-    if (index_gradient_query)
-    {
-        std::cout << "Index gradient query result - gradient " << common_robotics_utilities::print::Print(index_gradient_query.Value()) << std::endl;
-    }
-    const auto location_gradient_query = sdf.GetCoarseGradient(x_location, y_location, z_location, true); // Usually, you want to enable 'edge gradients' i.e. gradients for cells on the edge of the grid that don't have 6 neighbors
-    if (location_gradient_query)
-    {
-        std::cout << "Location gradient query result - gradient " << common_robotics_utilities::print::Print(location_gradient_query.Value()) << std::endl;
-    }
-    // Let's display the results to Rviz
-    Marker sdf_marker = voxelized_geometry_tools::ros_interface::ExportSDFForDisplay<std::vector<float>>(sdf, 0.5); // Set the alpha for display
-    sdf_marker.ns = "sdf";
-    sdf_marker.id = 1;
-    display_fn(sdf_marker);
-    std::cout << "...done" << std::endl;
+  }
+
+    // We can also set by location - occupancy values > 0.5 are obstacles
+  const voxelized_geometry_tools::CollisionCell obstacle_cell(1.0);
+  collision_map.SetValue(0.0, 0.0, 0.0, obstacle_cell);
+
+  // Let's get some values
+  // We can query by index
+  int64_t x_index = 10;
+  int64_t y_index = 10;
+  int64_t z_index = 10;
+  const auto index_query =
+      collision_map.GetImmutable(x_index, y_index, z_index);
+
+  // Is it in the grid?
+  if (index_query)
+  {
+    std::cout << "Index query result - stored value "
+              << index_query.Value().Occupancy() << " (occupancy) "
+              << index_query.Value().Component() << " (component)" << std::endl;
+  }
+
+  // Or we can query by location
+  double x_location = 0.0;
+  double y_location = 0.0;
+  double z_location = 0.0;
+  const auto location_query =
+      collision_map.GetImmutable(x_location, y_location, z_location);
+
+  // Is it in the grid?
+  if (location_query)
+  {
+    std::cout << "Location query result - stored value "
+              << location_query.Value().Occupancy() << " (occupancy) "
+              << location_query.Value().Component() << " (component)"
+              << std::endl;
+  }
+
+  // Let's compute connected components
+  const uint32_t num_connected_components =
+      collision_map.UpdateConnectedComponents();
+  std::cout << " There are " << num_connected_components
+            << " connected components in the grid" << std::endl;
+
+  // Let's display the results to Rviz
+  // First, the CollisionMap itself
+  // We need to provide colors to use
+  ColorRGBA collision_color;
+  collision_color.r = 1.0;
+  collision_color.g = 0.0;
+  collision_color.b = 0.0;
+  collision_color.a = 0.5;
+  ColorRGBA free_color;
+  free_color.r = 0.0;
+  free_color.g = 1.0;
+  free_color.b = 0.0;
+  free_color.a = 0.5;
+  ColorRGBA unknown_color;
+  unknown_color.r = 1.0;
+  unknown_color.g = 1.0;
+  unknown_color.b = 0.0;
+  unknown_color.a = 0.5;
+  Marker collision_map_marker =
+      voxelized_geometry_tools::ros_interface::ExportForDisplay(
+          collision_map, collision_color, free_color, unknown_color);
+  // To be safe, you'll need to set these yourself. The namespace (ns) value
+  // should distinguish between different things being displayed while the id
+  // value lets you have multiple versions of the same message at once. Always
+  // set this to 1 if you only want one copy.
+  collision_map_marker.ns = "collision_map";
+  collision_map_marker.id = 1;
+  // Send it off for display
+  display_fn(collision_map_marker);
+  // Now, let's draw the connected components
+  // Generally, you don't want a special color for unknown [P(occupancy) = 0.5]
+  // components.
+  Marker connected_components_marker =
+      voxelized_geometry_tools::ros_interface
+          ::ExportConnectedComponentsForDisplay(collision_map, false);
+  connected_components_marker.ns = "connected_components";
+  connected_components_marker.id = 1;
+  display_fn(connected_components_marker);
+
+  ///////////////////////////
+  //// Let's make an SDF ////
+  ///////////////////////////
+  // We pick a reasonable out-of-bounds value
+  const float oob_value = std::numeric_limits<float>::infinity();
+  // We start by extracting the SDF from the CollisionMap
+  const auto sdf_with_extrema = collision_map.ExtractSignedDistanceFieldFloat(
+      oob_value, true, false, false);
+  const auto& sdf = sdf_with_extrema.DistanceField();
+  std::cout << "Maximum distance in the SDF: " << sdf_with_extrema.Maximum()
+            << ", minimum distance in the SDF: " << sdf_with_extrema.Minimum()
+            << std::endl;
+
+  // Let's get some values
+  const auto index_sdf_query = sdf.GetImmutable(x_index, y_index, z_index);
+  // Is it in the grid?
+  if (index_sdf_query)
+  {
+    std::cout << "Index query result - stored distance "
+              << index_sdf_query.Value() << std::endl;
+  }
+  const auto location_sdf_query =
+      sdf.GetImmutable(x_location, y_location, z_location);
+  if (location_sdf_query)
+  {
+    std::cout << "Location query result - stored distance "
+              << location_sdf_query.Value() << std::endl;
+  }
+
+  // Let's get some gradients
+  // Usually, you want to enable 'edge gradients' i.e. gradients for cells on
+  // the edge of the grid that don't have 6 neighbors.
+  const auto index_gradient_query =
+      sdf.GetCoarseGradient(x_index, y_index, z_index, true);
+  if (index_gradient_query)
+  {
+    std::cout << "Index gradient query result - gradient "
+              << common_robotics_utilities::print::Print(
+                  index_gradient_query.Value())
+              << std::endl;
+  }
+  const auto location_gradient_query =
+      sdf.GetCoarseGradient(x_location, y_location, z_location, true);
+  if (location_gradient_query)
+  {
+    std::cout << "Location gradient query result - gradient "
+              << common_robotics_utilities::print::Print(
+                  location_gradient_query.Value())
+              << std::endl;
+  }
+
+  // Let's display the results to Rviz
+  Marker sdf_marker =
+      voxelized_geometry_tools::ros_interface::ExportSDFForDisplay(sdf, 0.5);
+  sdf_marker.ns = "sdf";
+  sdf_marker.id = 1;
+  display_fn(sdf_marker);
+  std::cout << "...done" << std::endl;
 #if VOXELIZED_GEOMETRY_TOOLS__SUPPORTED_ROS_VERSION == 2
-    rclcpp::spin(node);
-    rclcpp::shutdown();
+  rclcpp::spin(node);
+  rclcpp::shutdown();
 #elif VOXELIZED_GEOMETRY_TOOLS__SUPPORTED_ROS_VERSION == 1
-    ros::spin();
+  ros::spin();
 #endif
-    return 0;
+  return 0;
 }

--- a/include/voxelized_geometry_tools/collision_map.hpp
+++ b/include/voxelized_geometry_tools/collision_map.hpp
@@ -5,6 +5,7 @@
 #include <functional>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -231,12 +232,12 @@ public:
   topology_computation::TopologicalInvariants ComputeComponentTopology(
       const COMPONENT_TYPES component_types_to_use, const bool verbose);
 
-  template<typename BackingStore=std::vector<float>>
-  signed_distance_field_generation::SignedDistanceFieldResult<BackingStore>
-  ExtractSignedDistanceField(const float oob_value,
-                             const bool unknown_is_filled,
-                             const bool use_parallel,
-                             const bool add_virtual_border) const
+  template<typename ScalarType>
+  signed_distance_field_generation::SignedDistanceFieldResult<ScalarType>
+  ExtractSignedDistanceField(
+      const ScalarType oob_value = std::numeric_limits<ScalarType>::infinity(),
+      const bool unknown_is_filled = true, const bool use_parallel = false,
+      const bool add_virtual_border = false) const
   {
     using common_robotics_utilities::voxel_grid::GridIndex;
     // Make the helper function
@@ -265,17 +266,23 @@ public:
         throw std::runtime_error("index out of grid bounds");
       }
     };
-    return signed_distance_field_generation::ExtractSignedDistanceField
-        <CollisionCell, std::vector<CollisionCell>, BackingStore>(
-            *this, is_filled_fn, oob_value, GetFrame(), use_parallel,
-            add_virtual_border);
+    return
+        signed_distance_field_generation::internal::ExtractSignedDistanceField
+            <CollisionCell, std::vector<CollisionCell>, ScalarType>(
+                *this, is_filled_fn, oob_value, GetFrame(), use_parallel,
+                add_virtual_border);
   }
 
-  signed_distance_field_generation
-      ::SignedDistanceFieldResult<std::vector<float>>
-  ExtractSignedDistanceField(const float oob_value,
-                             const bool unknown_is_filled,
-                             const bool use_parallel,
-                             const bool add_virtual_border) const;
+  signed_distance_field_generation::SignedDistanceFieldResult<double>
+  ExtractSignedDistanceFieldDouble(
+      const double oob_value = std::numeric_limits<double>::infinity(),
+      const bool unknown_is_filled = true, const bool use_parallel = false,
+      const bool add_virtual_border = false) const;
+
+  signed_distance_field_generation::SignedDistanceFieldResult<float>
+  ExtractSignedDistanceFieldFloat(
+      const float oob_value = std::numeric_limits<float>::infinity(),
+      const bool unknown_is_filled = true, const bool use_parallel = false,
+      const bool add_virtual_border = false) const;
 };
 }  // namespace voxelized_geometry_tools

--- a/include/voxelized_geometry_tools/ros_interface.hpp
+++ b/include/voxelized_geometry_tools/ros_interface.hpp
@@ -356,13 +356,12 @@ ExportDynamicSpatialHashedVoxelGridToRViz(
 
 /// Export SDF to RViz display.
 
-template<typename BackingStore=std::vector<float>>
+template<typename ScalarType>
 inline Marker ExportSDFForDisplay(
-    const SignedDistanceField<BackingStore>& sdf,
-    const float alpha = 0.01f)
+    const SignedDistanceField<ScalarType>& sdf, const float alpha = 0.01f)
 {
-  float min_distance = 0.0;
-  float max_distance = 0.0;
+  ScalarType min_distance = 0.0;
+  ScalarType max_distance = 0.0;
   for (int64_t x_index = 0; x_index < sdf.GetNumXCells(); x_index++)
   {
     for (int64_t y_index = 0; y_index < sdf.GetNumYCells(); y_index++)
@@ -370,7 +369,7 @@ inline Marker ExportSDFForDisplay(
       for (int64_t z_index = 0; z_index < sdf.GetNumZCells(); z_index++)
       {
         // Update minimum/maximum distance variables
-        const float distance
+        const ScalarType distance
             = sdf.GetImmutable(x_index, y_index, z_index).Value();
         if (distance < min_distance)
         {
@@ -384,7 +383,7 @@ inline Marker ExportSDFForDisplay(
     }
   }
   const auto color_fn
-      = [&] (const float& distance,
+      = [&] (const ScalarType& distance,
              const common_robotics_utilities::voxel_grid::GridIndex&)
   {
     ColorRGBA new_color;
@@ -412,17 +411,16 @@ inline Marker ExportSDFForDisplay(
     }
     return new_color;
   };
-  auto display_rep = ExportVoxelGridToRViz<float, BackingStore>(
-      sdf, sdf.GetFrame(), color_fn);
+  auto display_rep =
+      ExportVoxelGridToRViz<ScalarType>(sdf, sdf.GetFrame(), color_fn);
   display_rep.ns = "sdf_distance";
   display_rep.id = 1;
   return display_rep;
 }
 
-template<typename BackingStore=std::vector<float>>
+template<typename ScalarType>
 inline Marker ExportSDFForDisplayCollisionOnly(
-    const SignedDistanceField<BackingStore>& sdf,
-    const float alpha = 0.01f)
+    const SignedDistanceField<ScalarType>& sdf, const float alpha = 0.01f)
 {
   const ColorRGBA filled_color
       = common_robotics_utilities::color_builder
@@ -443,8 +441,8 @@ inline Marker ExportSDFForDisplayCollisionOnly(
       return free_color;
     }
   };
-  auto display_rep = ExportVoxelGridToRViz<float, BackingStore>(
-      sdf, sdf.GetFrame(), color_fn);
+  auto display_rep =
+      ExportVoxelGridToRViz<ScalarType>(sdf, sdf.GetFrame(), color_fn);
   display_rep.ns = "sdf_collision";
   display_rep.id = 1;
   return display_rep;
@@ -452,22 +450,22 @@ inline Marker ExportSDFForDisplayCollisionOnly(
 
 /// Convert SDF to and from ROS messages.
 
-template<typename BackingStore=std::vector<float>>
+template<typename ScalarType>
 inline SignedDistanceFieldMessage GetMessageRepresentation(
-    const SignedDistanceField<BackingStore>& sdf)
+    const SignedDistanceField<ScalarType>& sdf)
 {
   SignedDistanceFieldMessage sdf_message;
   sdf_message.header.frame_id = sdf.GetFrame();
   std::vector<uint8_t> buffer;
-  SignedDistanceField<BackingStore>::Serialize(sdf, buffer);
+  SignedDistanceField<ScalarType>::Serialize(sdf, buffer);
   sdf_message.serialized_sdf
       = common_robotics_utilities::zlib_helpers::CompressBytes(buffer);
   sdf_message.is_compressed = true;
   return sdf_message;
 }
 
-template<typename BackingStore=std::vector<float>>
-inline SignedDistanceField<BackingStore> LoadFromMessageRepresentation(
+template<typename ScalarType>
+inline SignedDistanceField<ScalarType> LoadFromMessageRepresentation(
     const SignedDistanceFieldMessage& message)
 {
   if (message.is_compressed)
@@ -475,12 +473,12 @@ inline SignedDistanceField<BackingStore> LoadFromMessageRepresentation(
     const std::vector<uint8_t> decompressed_sdf
         = common_robotics_utilities::zlib_helpers::DecompressBytes(
             message.serialized_sdf);
-    return SignedDistanceField<BackingStore>::Deserialize(
+    return SignedDistanceField<ScalarType>::Deserialize(
         decompressed_sdf, 0).Value();
   }
   else
   {
-    return SignedDistanceField<BackingStore>::Deserialize(
+    return SignedDistanceField<ScalarType>::Deserialize(
         message.serialized_sdf, 0).Value();
   }
 }

--- a/src/voxelized_geometry_tools/collision_map.cpp
+++ b/src/voxelized_geometry_tools/collision_map.cpp
@@ -610,12 +610,21 @@ CollisionMap::ComputeComponentTopology(
                                                         verbose);
 }
 
-signed_distance_field_generation::SignedDistanceFieldResult<std::vector<float>>
-CollisionMap::ExtractSignedDistanceField(
+signed_distance_field_generation::SignedDistanceFieldResult<double>
+CollisionMap::ExtractSignedDistanceFieldDouble(
+    const double oob_value, const bool unknown_is_filled,
+    const bool use_parallel, const bool add_virtual_border) const
+{
+  return ExtractSignedDistanceField<double>(
+      oob_value, unknown_is_filled, use_parallel, add_virtual_border);
+}
+
+signed_distance_field_generation::SignedDistanceFieldResult<float>
+CollisionMap::ExtractSignedDistanceFieldFloat(
     const float oob_value, const bool unknown_is_filled,
     const bool use_parallel, const bool add_virtual_border) const
 {
-  return ExtractSignedDistanceField<std::vector<float>>(
+  return ExtractSignedDistanceField<float>(
       oob_value, unknown_is_filled, use_parallel, add_virtual_border);
 }
 }  // namespace voxelized_geometry_tools

--- a/src/voxelized_geometry_tools/mesh_rasterizer.cpp
+++ b/src/voxelized_geometry_tools/mesh_rasterizer.cpp
@@ -64,7 +64,7 @@ Eigen::Vector3d CalcClosestPointOnTriangle(
     const Eigen::Vector3d p_MQprojected =
         p_Mv1 + common_robotics_utilities::math::VectorRejection(normal, v_v1Q);
     p_MQclosest = p_MQprojected;
-  } 
+  }
   else
   {
     const Eigen::Vector3d p_MQclosest12 =

--- a/src/voxelized_geometry_tools/signed_distance_field.cpp
+++ b/src/voxelized_geometry_tools/signed_distance_field.cpp
@@ -1,0 +1,4 @@
+#include <voxelized_geometry_tools/signed_distance_field.hpp>
+
+template class voxelized_geometry_tools::SignedDistanceField<double>;
+template class voxelized_geometry_tools::SignedDistanceField<float>;

--- a/src/voxelized_geometry_tools/signed_distance_field_generation.cpp
+++ b/src/voxelized_geometry_tools/signed_distance_field_generation.cpp
@@ -1,0 +1,6 @@
+#include <voxelized_geometry_tools/signed_distance_field_generation.hpp>
+
+template class voxelized_geometry_tools::signed_distance_field_generation
+    ::SignedDistanceFieldResult<double>;
+template class voxelized_geometry_tools::signed_distance_field_generation
+    ::SignedDistanceFieldResult<float>;

--- a/src/voxelized_geometry_tools/tagged_object_collision_map.cpp
+++ b/src/voxelized_geometry_tools/tagged_object_collision_map.cpp
@@ -568,43 +568,83 @@ TaggedObjectCollisionMap::ComputeComponentTopology(
                                                         verbose);
 }
 
-signed_distance_field_generation::SignedDistanceFieldResult<std::vector<float>>
-TaggedObjectCollisionMap::ExtractSignedDistanceField(
-    const std::vector<uint32_t>& objects_to_use, const float oob_value,
+signed_distance_field_generation::SignedDistanceFieldResult<double>
+TaggedObjectCollisionMap::ExtractSignedDistanceFieldDouble(
+    const std::vector<uint32_t>& objects_to_use, const double oob_value,
     const bool unknown_is_filled, const bool use_parallel,
     const bool add_virtual_border) const
 {
-  return ExtractSignedDistanceField<std::vector<float>>(
+  return ExtractSignedDistanceField<double>(
       objects_to_use, oob_value, unknown_is_filled, use_parallel,
       add_virtual_border);
 }
 
-std::map<uint32_t, SignedDistanceField<std::vector<float>>>
-TaggedObjectCollisionMap::MakeSeparateObjectSDFs(
-    const std::vector<uint32_t>& object_ids, const float oob_value,
+signed_distance_field_generation::SignedDistanceFieldResult<float>
+TaggedObjectCollisionMap::ExtractSignedDistanceFieldFloat(
+    const std::vector<uint32_t>& objects_to_use, const float oob_value,
     const bool unknown_is_filled, const bool use_parallel,
     const bool add_virtual_border) const
 {
-  return MakeSeparateObjectSDFs<std::vector<float>>(
+  return ExtractSignedDistanceField<float>(
+      objects_to_use, oob_value, unknown_is_filled, use_parallel,
+      add_virtual_border);
+}
+
+std::map<uint32_t, SignedDistanceField<double>>
+TaggedObjectCollisionMap::MakeSeparateObjectSDFsDouble(
+    const std::vector<uint32_t>& object_ids, const double oob_value,
+    const bool unknown_is_filled, const bool use_parallel,
+    const bool add_virtual_border) const
+{
+  return MakeSeparateObjectSDFs<double>(
       object_ids, oob_value, unknown_is_filled, use_parallel,
       add_virtual_border);
 }
 
-std::map<uint32_t, SignedDistanceField<std::vector<float>>>
-TaggedObjectCollisionMap::MakeAllObjectSDFs(
-    const float oob_value, const bool unknown_is_filled,
+std::map<uint32_t, SignedDistanceField<float>>
+TaggedObjectCollisionMap::MakeSeparateObjectSDFsFloat(
+    const std::vector<uint32_t>& object_ids, const float oob_value,
+    const bool unknown_is_filled, const bool use_parallel,
+    const bool add_virtual_border) const
+{
+  return MakeSeparateObjectSDFs<float>(
+      object_ids, oob_value, unknown_is_filled, use_parallel,
+      add_virtual_border);
+}
+
+std::map<uint32_t, SignedDistanceField<double>>
+TaggedObjectCollisionMap::MakeAllObjectSDFsDouble(
+    const double oob_value, const bool unknown_is_filled,
     const bool use_parallel, const bool add_virtual_border) const
 {
-  return MakeAllObjectSDFs<std::vector<float>>(
+  return MakeAllObjectSDFs<double>(
       oob_value, unknown_is_filled, use_parallel, add_virtual_border);
 }
 
-signed_distance_field_generation::SignedDistanceFieldResult<std::vector<float>>
-TaggedObjectCollisionMap::ExtractFreeAndNamedObjectsSignedDistanceField(
+std::map<uint32_t, SignedDistanceField<float>>
+TaggedObjectCollisionMap::MakeAllObjectSDFsFloat(
+    const float oob_value, const bool unknown_is_filled,
+    const bool use_parallel, const bool add_virtual_border) const
+{
+  return MakeAllObjectSDFs<float>(
+      oob_value, unknown_is_filled, use_parallel, add_virtual_border);
+}
+
+signed_distance_field_generation::SignedDistanceFieldResult<double>
+TaggedObjectCollisionMap::ExtractFreeAndNamedObjectsSignedDistanceFieldDouble(
+    const double oob_value, const bool unknown_is_filled,
+    const bool use_parallel) const
+{
+  return ExtractFreeAndNamedObjectsSignedDistanceField<double>(
+      oob_value, unknown_is_filled, use_parallel);
+}
+
+signed_distance_field_generation::SignedDistanceFieldResult<float>
+TaggedObjectCollisionMap::ExtractFreeAndNamedObjectsSignedDistanceFieldFloat(
     const float oob_value, const bool unknown_is_filled,
     const bool use_parallel) const
 {
-  return ExtractFreeAndNamedObjectsSignedDistanceField<std::vector<float>>(
+  return ExtractFreeAndNamedObjectsSignedDistanceField<float>(
       oob_value, unknown_is_filled, use_parallel);
 }
 
@@ -711,13 +751,12 @@ uint32_t TaggedObjectCollisionMap::UpdateSpatialSegments(
   spatial_segments_valid_ = false;
   const auto sdf_result
       = (add_virtual_border)
-        ? ExtractSignedDistanceField(
+        ? ExtractSignedDistanceFieldFloat(
               std::vector<uint32_t>(), std::numeric_limits<float>::infinity(),
               true, use_parallel, true)
-        : ExtractFreeAndNamedObjectsSignedDistanceField(
+        : ExtractFreeAndNamedObjectsSignedDistanceFieldFloat(
               std::numeric_limits<float>::infinity(), true, use_parallel);
-  const SignedDistanceField<std::vector<float>>& sdf
-      = sdf_result.DistanceField();
+  const auto& sdf = sdf_result.DistanceField();
   const auto extrema_map = sdf.ComputeLocalExtremaMap();
   // Make the helper functions
   // This is not enough, we also need to limit the curvature of the


### PR DESCRIPTION
Previously, `SignedDistanceField` was templated on the backing store type. This was intended to support alternate backing types, such as `thrust::host_vector`. However, in the following years, this capacity has never been used and can be removed. Instead, templating on the scalar type and explicitly instantiating on `float` and `double` types better covers our current and future needs.

In addition, this PR moves most of the signed distance field generation code to an internal namespace to make it clear that this API is not intended to be stable.