### PR TITLE
Cache SDF extrema to simplify SDF generation API

### DIFF
--- a/example/estimate_distance.cpp
+++ b/example/estimate_distance.cpp
@@ -87,8 +87,7 @@ void test_estimate_distance(
   const auto map_marker =
       voxelized_geometry_tools::ros_interface::ExportForDisplay(
           map, collision_color, free_color, unknown_color);
-  const auto sdf = map.ExtractSignedDistanceFieldFloat(
-      1e6, true, false, false).DistanceField();
+  const auto sdf = map.ExtractSignedDistanceFieldFloat(1e6, true, false, false);
   const auto sdf_marker =
       voxelized_geometry_tools::ros_interface::ExportSDFForDisplay(sdf, 0.05f);
 

--- a/example/spatial_segments.cpp
+++ b/example/spatial_segments.cpp
@@ -137,20 +137,18 @@ void test_spatial_segments(
     }
   }
 
-  const auto sdf_result = tocmap.ExtractSignedDistanceFieldFloat(
+  const auto sdf = tocmap.ExtractSignedDistanceFieldFloat(
       std::vector<uint32_t>(), std::numeric_limits<float>::infinity(),
       true, false, false);
-  const auto& sdf = sdf_result.DistanceField();
   Marker sdf_marker =
       voxelized_geometry_tools::ros_interface::ExportSDFForDisplay(sdf, 1.0f);
   sdf_marker.id = 1;
   sdf_marker.ns = "environment_sdf_no_border";
   display_markers.markers.push_back(sdf_marker);
 
-  const auto virtual_border_sdf_result = tocmap.ExtractSignedDistanceFieldFloat(
+  const auto virtual_border_sdf = tocmap.ExtractSignedDistanceFieldFloat(
       std::vector<uint32_t>(), std::numeric_limits<float>::infinity(),
       true, false, true);
-  const auto& virtual_border_sdf = virtual_border_sdf_result.DistanceField();
   Marker virtual_border_sdf_marker = voxelized_geometry_tools::ros_interface
       ::ExportSDFForDisplay(virtual_border_sdf, 1.0f);
   virtual_border_sdf_marker.id = 1;

--- a/example/tutorial.cpp
+++ b/example/tutorial.cpp
@@ -186,11 +186,11 @@ int main(int argc, char** argv)
   // We pick a reasonable out-of-bounds value
   const float oob_value = std::numeric_limits<float>::infinity();
   // We start by extracting the SDF from the CollisionMap
-  const auto sdf_with_extrema = collision_map.ExtractSignedDistanceFieldFloat(
+  const auto sdf = collision_map.ExtractSignedDistanceFieldFloat(
       oob_value, true, false, false);
-  const auto& sdf = sdf_with_extrema.DistanceField();
-  std::cout << "Maximum distance in the SDF: " << sdf_with_extrema.Maximum()
-            << ", minimum distance in the SDF: " << sdf_with_extrema.Minimum()
+  const auto sdf_extrema = sdf.GetMinimumMaximum();
+  std::cout << "Maximum distance in the SDF: " << sdf_extrema.Maximum()
+            << ", minimum distance in the SDF: " << sdf_extrema.Minimum()
             << std::endl;
 
   // Let's get some values

--- a/include/voxelized_geometry_tools/collision_map.hpp
+++ b/include/voxelized_geometry_tools/collision_map.hpp
@@ -233,8 +233,7 @@ public:
       const COMPONENT_TYPES component_types_to_use, const bool verbose);
 
   template<typename ScalarType>
-  signed_distance_field_generation::SignedDistanceFieldResult<ScalarType>
-  ExtractSignedDistanceField(
+  SignedDistanceField<ScalarType> ExtractSignedDistanceField(
       const ScalarType oob_value = std::numeric_limits<ScalarType>::infinity(),
       const bool unknown_is_filled = true, const bool use_parallel = false,
       const bool add_virtual_border = false) const
@@ -273,14 +272,12 @@ public:
                 add_virtual_border);
   }
 
-  signed_distance_field_generation::SignedDistanceFieldResult<double>
-  ExtractSignedDistanceFieldDouble(
+  SignedDistanceField<double> ExtractSignedDistanceFieldDouble(
       const double oob_value = std::numeric_limits<double>::infinity(),
       const bool unknown_is_filled = true, const bool use_parallel = false,
       const bool add_virtual_border = false) const;
 
-  signed_distance_field_generation::SignedDistanceFieldResult<float>
-  ExtractSignedDistanceFieldFloat(
+  SignedDistanceField<float> ExtractSignedDistanceFieldFloat(
       const float oob_value = std::numeric_limits<float>::infinity(),
       const bool unknown_is_filled = true, const bool use_parallel = false,
       const bool add_virtual_border = false) const;

--- a/src/voxelized_geometry_tools/collision_map.cpp
+++ b/src/voxelized_geometry_tools/collision_map.cpp
@@ -610,8 +610,7 @@ CollisionMap::ComputeComponentTopology(
                                                         verbose);
 }
 
-signed_distance_field_generation::SignedDistanceFieldResult<double>
-CollisionMap::ExtractSignedDistanceFieldDouble(
+SignedDistanceField<double> CollisionMap::ExtractSignedDistanceFieldDouble(
     const double oob_value, const bool unknown_is_filled,
     const bool use_parallel, const bool add_virtual_border) const
 {
@@ -619,8 +618,7 @@ CollisionMap::ExtractSignedDistanceFieldDouble(
       oob_value, unknown_is_filled, use_parallel, add_virtual_border);
 }
 
-signed_distance_field_generation::SignedDistanceFieldResult<float>
-CollisionMap::ExtractSignedDistanceFieldFloat(
+SignedDistanceField<float> CollisionMap::ExtractSignedDistanceFieldFloat(
     const float oob_value, const bool unknown_is_filled,
     const bool use_parallel, const bool add_virtual_border) const
 {

--- a/src/voxelized_geometry_tools/signed_distance_field_generation.cpp
+++ b/src/voxelized_geometry_tools/signed_distance_field_generation.cpp
@@ -449,8 +449,3 @@ DistanceField BuildDistanceField(
 }  // namespace internal
 }  // namespace signed_distance_field_generation
 }  // namespace voxelized_geometry_tools
-
-template class voxelized_geometry_tools::signed_distance_field_generation
-    ::SignedDistanceFieldResult<double>;
-template class voxelized_geometry_tools::signed_distance_field_generation
-    ::SignedDistanceFieldResult<float>;

--- a/src/voxelized_geometry_tools/tagged_object_collision_map.cpp
+++ b/src/voxelized_geometry_tools/tagged_object_collision_map.cpp
@@ -568,7 +568,7 @@ TaggedObjectCollisionMap::ComputeComponentTopology(
                                                         verbose);
 }
 
-signed_distance_field_generation::SignedDistanceFieldResult<double>
+SignedDistanceField<double>
 TaggedObjectCollisionMap::ExtractSignedDistanceFieldDouble(
     const std::vector<uint32_t>& objects_to_use, const double oob_value,
     const bool unknown_is_filled, const bool use_parallel,
@@ -579,7 +579,7 @@ TaggedObjectCollisionMap::ExtractSignedDistanceFieldDouble(
       add_virtual_border);
 }
 
-signed_distance_field_generation::SignedDistanceFieldResult<float>
+SignedDistanceField<float>
 TaggedObjectCollisionMap::ExtractSignedDistanceFieldFloat(
     const std::vector<uint32_t>& objects_to_use, const float oob_value,
     const bool unknown_is_filled, const bool use_parallel,
@@ -630,7 +630,7 @@ TaggedObjectCollisionMap::MakeAllObjectSDFsFloat(
       oob_value, unknown_is_filled, use_parallel, add_virtual_border);
 }
 
-signed_distance_field_generation::SignedDistanceFieldResult<double>
+SignedDistanceField<double>
 TaggedObjectCollisionMap::ExtractFreeAndNamedObjectsSignedDistanceFieldDouble(
     const double oob_value, const bool unknown_is_filled,
     const bool use_parallel) const
@@ -639,7 +639,7 @@ TaggedObjectCollisionMap::ExtractFreeAndNamedObjectsSignedDistanceFieldDouble(
       oob_value, unknown_is_filled, use_parallel);
 }
 
-signed_distance_field_generation::SignedDistanceFieldResult<float>
+SignedDistanceField<float>
 TaggedObjectCollisionMap::ExtractFreeAndNamedObjectsSignedDistanceFieldFloat(
     const float oob_value, const bool unknown_is_filled,
     const bool use_parallel) const
@@ -747,14 +747,13 @@ uint32_t TaggedObjectCollisionMap::UpdateSpatialSegments(
     return number_of_spatial_segments_;
   }
   spatial_segments_valid_ = false;
-  const auto sdf_result
+  const auto sdf
       = (add_virtual_border)
         ? ExtractSignedDistanceFieldFloat(
               std::vector<uint32_t>(), std::numeric_limits<float>::infinity(),
               true, use_parallel, true)
         : ExtractFreeAndNamedObjectsSignedDistanceFieldFloat(
               std::numeric_limits<float>::infinity(), true, use_parallel);
-  const auto& sdf = sdf_result.DistanceField();
   const auto extrema_map = sdf.ComputeLocalExtremaMap();
   // Make the helper functions
   // This is not enough, we also need to limit the curvature of the


### PR DESCRIPTION
Caches the extrema (minimum & maximum distances) of signed distance fields, locks generated signed distance fields after creation, and removes the need for the existing `SignedDistanceFieldResult<ScalarType>` type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/voxelized_geometry_tools/33)
<!-- Reviewable:end -->
