### PR TITLE
Replace iostream logging with configurable logging functions

### DIFF
--- a/example/pointcloud_voxelization.cpp
+++ b/example/pointcloud_voxelization.cpp
@@ -262,7 +262,7 @@ void test_pointcloud_voxelization(
                                    environment_display.markers.begin(),
                                    environment_display.markers.end());
   }
-  catch (std::runtime_error& ex)
+  catch (const std::runtime_error& ex)
   {
     std::cerr << ex.what() << std::endl;
   }
@@ -287,7 +287,7 @@ void test_pointcloud_voxelization(
                                    environment_display.markers.begin(),
                                    environment_display.markers.end());
   }
-  catch (std::runtime_error& ex)
+  catch (const std::runtime_error& ex)
   {
     std::cerr << ex.what() << std::endl;
   }
@@ -312,7 +312,7 @@ void test_pointcloud_voxelization(
                                    environment_display.markers.begin(),
                                    environment_display.markers.end());
   }
-  catch (std::runtime_error&)
+  catch (const std::runtime_error&)
   {
     throw std::runtime_error("CPU PointCloud Voxelizer is not available");
   }

--- a/include/voxelized_geometry_tools/collision_map.hpp
+++ b/include/voxelized_geometry_tools/collision_map.hpp
@@ -16,6 +16,7 @@
 #include <Eigen/Geometry>
 #include <common_robotics_utilities/maybe.hpp>
 #include <common_robotics_utilities/serialization.hpp>
+#include <common_robotics_utilities/utility.hpp>
 #include <common_robotics_utilities/voxel_grid.hpp>
 #include <voxelized_geometry_tools/signed_distance_field.hpp>
 #include <voxelized_geometry_tools/signed_distance_field_generation.hpp>
@@ -230,7 +231,9 @@ public:
   ExtractEmptyComponentSurfaces() const;
 
   topology_computation::TopologicalInvariants ComputeComponentTopology(
-      const COMPONENT_TYPES component_types_to_use, const bool verbose);
+      const COMPONENT_TYPES component_types_to_use,
+      const common_robotics_utilities::utility::LoggingFunction& logging_fn =
+          common_robotics_utilities::utility::NoOpLoggingFunction());
 
   template<typename ScalarType>
   SignedDistanceField<ScalarType> ExtractSignedDistanceField(

--- a/include/voxelized_geometry_tools/collision_map.hpp
+++ b/include/voxelized_geometry_tools/collision_map.hpp
@@ -232,8 +232,8 @@ public:
 
   topology_computation::TopologicalInvariants ComputeComponentTopology(
       const COMPONENT_TYPES component_types_to_use,
-      const common_robotics_utilities::utility::LoggingFunction& logging_fn =
-          common_robotics_utilities::utility::NoOpLoggingFunction());
+      const common_robotics_utilities::utility::LoggingFunction&
+          logging_fn = {});
 
   template<typename ScalarType>
   SignedDistanceField<ScalarType> ExtractSignedDistanceField(

--- a/include/voxelized_geometry_tools/cuda_voxelization_helpers.h
+++ b/include/voxelized_geometry_tools/cuda_voxelization_helpers.h
@@ -17,7 +17,9 @@ namespace cuda_helpers
 std::vector<AvailableDevice> GetAvailableDevices();
 
 std::unique_ptr<DeviceVoxelizationHelperInterface>
-MakeCudaVoxelizationHelper(const std::map<std::string, int32_t>& options);
+MakeCudaVoxelizationHelper(
+    const std::map<std::string, int32_t>& options,
+    const LoggingFunction& logging_fn);
 }  // namespace cuda_helpers
 }  // namespace pointcloud_voxelization
 }  // namespace voxelized_geometry_tools

--- a/include/voxelized_geometry_tools/device_pointcloud_voxelization.hpp
+++ b/include/voxelized_geometry_tools/device_pointcloud_voxelization.hpp
@@ -56,8 +56,9 @@ private:
 class CudaPointCloudVoxelizer : public DevicePointCloudVoxelizer
 {
 public:
-  explicit CudaPointCloudVoxelizer(
-      const std::map<std::string, int32_t>& options);
+  CudaPointCloudVoxelizer(
+      const std::map<std::string, int32_t>& options,
+      const LoggingFunction& logging_fn = NoOpLoggingFunction());
 };
 
 /// Implementation of device-accelerated pointcloud voxelization for OpenCL
@@ -65,8 +66,9 @@ public:
 class OpenCLPointCloudVoxelizer : public DevicePointCloudVoxelizer
 {
 public:
-  explicit OpenCLPointCloudVoxelizer(
-      const std::map<std::string, int32_t>& options);
+  OpenCLPointCloudVoxelizer(
+      const std::map<std::string, int32_t>& options,
+      const LoggingFunction& logging_fn = NoOpLoggingFunction());
 };
 
 }  // namespace pointcloud_voxelization

--- a/include/voxelized_geometry_tools/device_pointcloud_voxelization.hpp
+++ b/include/voxelized_geometry_tools/device_pointcloud_voxelization.hpp
@@ -58,7 +58,7 @@ class CudaPointCloudVoxelizer : public DevicePointCloudVoxelizer
 public:
   CudaPointCloudVoxelizer(
       const std::map<std::string, int32_t>& options,
-      const LoggingFunction& logging_fn = NoOpLoggingFunction());
+      const LoggingFunction& logging_fn = {});
 };
 
 /// Implementation of device-accelerated pointcloud voxelization for OpenCL
@@ -68,7 +68,7 @@ class OpenCLPointCloudVoxelizer : public DevicePointCloudVoxelizer
 public:
   OpenCLPointCloudVoxelizer(
       const std::map<std::string, int32_t>& options,
-      const LoggingFunction& logging_fn = NoOpLoggingFunction());
+      const LoggingFunction& logging_fn = {});
 };
 
 }  // namespace pointcloud_voxelization

--- a/include/voxelized_geometry_tools/device_voxelization_interface.hpp
+++ b/include/voxelized_geometry_tools/device_voxelization_interface.hpp
@@ -17,12 +17,6 @@ namespace pointcloud_voxelization
 // handling includes for device-specific compilers (e.g. NVCC).
 using LoggingFunction = std::function<void(const std::string&)>;
 
-/// Make a do-nothing logging function.
-inline LoggingFunction NoOpLoggingFunction()
-{
-  return [] (const std::string&) {};
-}
-
 // Wrapper for device name and the options necessary to retrieve it.
 class AvailableDevice
 {
@@ -53,15 +47,22 @@ inline int32_t RetrieveOptionOrDefault(
   if (found_itr != options.end())
   {
     const int32_t value = found_itr->second;
-    logging_fn(
-        "Option [" + option + "] found, value [" + std::to_string(value) + "]");
+    if (logging_fn)
+    {
+      logging_fn(
+          "Option [" + option + "] found, value [" + std::to_string(value)
+          + "]");
+    }
     return value;
   }
   else
   {
-    logging_fn(
-        "Option [" + option + "] not found, default ["
-        + std::to_string(default_value) + "]");
+    if (logging_fn)
+    {
+      logging_fn(
+          "Option [" + option + "] not found, default ["
+          + std::to_string(default_value) + "]");
+    }
     return default_value;
   }
 }

--- a/include/voxelized_geometry_tools/device_voxelization_interface.hpp
+++ b/include/voxelized_geometry_tools/device_voxelization_interface.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <memory>
 #include <iostream>
@@ -11,6 +12,17 @@ namespace voxelized_geometry_tools
 {
 namespace pointcloud_voxelization
 {
+// Signature of basic text logging function. This is the same as CRU's logging
+// function type, but repeated here as some of our build systems are limited in
+// handling includes for device-specific compilers (e.g. NVCC).
+using LoggingFunction = std::function<void(const std::string&)>;
+
+/// Make a do-nothing logging function.
+inline LoggingFunction NoOpLoggingFunction()
+{
+  return [] (const std::string&) {};
+}
+
 // Wrapper for device name and the options necessary to retrieve it.
 class AvailableDevice
 {
@@ -35,20 +47,21 @@ private:
 // Helper for common option retrieval in device voxelizers.
 inline int32_t RetrieveOptionOrDefault(
     const std::map<std::string, int32_t>& options, const std::string& option,
-    const int32_t default_value)
+    const int32_t default_value, const LoggingFunction& logging_fn)
 {
   auto found_itr = options.find(option);
   if (found_itr != options.end())
   {
     const int32_t value = found_itr->second;
-    std::cout << "Option [" << option << "] found with value [" << value << "]"
-              << std::endl;
+    logging_fn(
+        "Option [" + option + "] found, value [" + std::to_string(value) + "]");
     return value;
   }
   else
   {
-    std::cout << "Option [" << option << "] not found, default ["
-              << default_value << "]" << std::endl;
+    logging_fn(
+        "Option [" + option + "] not found, default ["
+        + std::to_string(default_value) + "]");
     return default_value;
   }
 }

--- a/include/voxelized_geometry_tools/opencl_voxelization_helpers.h
+++ b/include/voxelized_geometry_tools/opencl_voxelization_helpers.h
@@ -17,7 +17,9 @@ namespace opencl_helpers
 std::vector<AvailableDevice> GetAvailableDevices();
 
 std::unique_ptr<DeviceVoxelizationHelperInterface>
-MakeOpenCLVoxelizationHelper(const std::map<std::string, int32_t>& options);
+MakeOpenCLVoxelizationHelper(
+    const std::map<std::string, int32_t>& options,
+    const LoggingFunction& logging_fn);
 }  // namespace opencl_helpers
 }  // namespace pointcloud_voxelization
 }  // namespace voxelized_geometry_tools

--- a/include/voxelized_geometry_tools/pointcloud_voxelization.hpp
+++ b/include/voxelized_geometry_tools/pointcloud_voxelization.hpp
@@ -54,15 +54,15 @@ std::vector<AvailableBackend> GetAvailableBackends();
 std::unique_ptr<PointCloudVoxelizationInterface> MakePointCloudVoxelizer(
     const BackendOptions backend_option,
     const std::map<std::string, int32_t>& device_options,
-    const LoggingFunction& logging_fn = NoOpLoggingFunction());
+    const LoggingFunction& logging_fn = {});
 
 std::unique_ptr<PointCloudVoxelizationInterface> MakePointCloudVoxelizer(
     const AvailableBackend& backend,
-    const LoggingFunction& logging_fn = NoOpLoggingFunction());
+    const LoggingFunction& logging_fn = {});
 
 std::unique_ptr<PointCloudVoxelizationInterface>
 MakeBestAvailablePointCloudVoxelizer(
     const std::map<std::string, int32_t>& device_options,
-    const LoggingFunction& logging_fn = NoOpLoggingFunction());
+    const LoggingFunction& logging_fn = {});
 }  // namespace pointcloud_voxelization
 }  // namespace voxelized_geometry_tools

--- a/include/voxelized_geometry_tools/pointcloud_voxelization.hpp
+++ b/include/voxelized_geometry_tools/pointcloud_voxelization.hpp
@@ -51,16 +51,18 @@ private:
 
 std::vector<AvailableBackend> GetAvailableBackends();
 
-std::unique_ptr<PointCloudVoxelizationInterface>
-MakePointCloudVoxelizer(
+std::unique_ptr<PointCloudVoxelizationInterface> MakePointCloudVoxelizer(
     const BackendOptions backend_option,
-    const std::map<std::string, int32_t>& device_options);
+    const std::map<std::string, int32_t>& device_options,
+    const LoggingFunction& logging_fn = NoOpLoggingFunction());
 
-std::unique_ptr<PointCloudVoxelizationInterface>
-MakePointCloudVoxelizer(const AvailableBackend& backend);
+std::unique_ptr<PointCloudVoxelizationInterface> MakePointCloudVoxelizer(
+    const AvailableBackend& backend,
+    const LoggingFunction& logging_fn = NoOpLoggingFunction());
 
 std::unique_ptr<PointCloudVoxelizationInterface>
 MakeBestAvailablePointCloudVoxelizer(
-    const std::map<std::string, int32_t>& device_options);
+    const std::map<std::string, int32_t>& device_options,
+    const LoggingFunction& logging_fn = NoOpLoggingFunction());
 }  // namespace pointcloud_voxelization
 }  // namespace voxelized_geometry_tools

--- a/include/voxelized_geometry_tools/pointcloud_voxelization_interface.hpp
+++ b/include/voxelized_geometry_tools/pointcloud_voxelization_interface.hpp
@@ -226,13 +226,16 @@ public:
       const CollisionMap& static_environment, const double step_size_multiplier,
       const PointCloudVoxelizationFilterOptions& filter_options,
       const std::vector<PointCloudWrapperSharedPtr>& pointclouds,
-      const std::function<void(const VoxelizerRuntime&)>& runtime_log_fn =
-          [] (const VoxelizerRuntime&){}) const {
+      const std::function<void(const VoxelizerRuntime&)>&
+          runtime_log_fn = {}) const {
     CollisionMap output_environment = static_environment;
     const auto voxelizer_runtime = VoxelizePointClouds(
         static_environment, step_size_multiplier, filter_options, pointclouds,
         output_environment);
-    runtime_log_fn(voxelizer_runtime);
+    if (runtime_log_fn)
+    {
+      runtime_log_fn(voxelizer_runtime);
+    }
     return output_environment;
   }
 

--- a/include/voxelized_geometry_tools/pointcloud_voxelization_interface.hpp
+++ b/include/voxelized_geometry_tools/pointcloud_voxelization_interface.hpp
@@ -226,17 +226,8 @@ public:
       const CollisionMap& static_environment, const double step_size_multiplier,
       const PointCloudVoxelizationFilterOptions& filter_options,
       const std::vector<PointCloudWrapperSharedPtr>& pointclouds,
-      const std::function<void(const VoxelizerRuntime&)>&
-          runtime_log_fn = [] (const VoxelizerRuntime& voxelizer_runtime)
-          {
-            const double raycasting_time = voxelizer_runtime.RaycastingTime();
-            const double filtering_time = voxelizer_runtime.FilteringTime();
-            std::cout
-                << "Raycasting time " << raycasting_time
-                << ", filtering time " << filtering_time
-                << ", total time " << raycasting_time + filtering_time
-                << std::endl;
-          }) const {
+      const std::function<void(const VoxelizerRuntime&)>& runtime_log_fn =
+          [] (const VoxelizerRuntime&){}) const {
     CollisionMap output_environment = static_environment;
     const auto voxelizer_runtime = VoxelizePointClouds(
         static_environment, step_size_multiplier, filter_options, pointclouds,

--- a/include/voxelized_geometry_tools/signed_distance_field.hpp
+++ b/include/voxelized_geometry_tools/signed_distance_field.hpp
@@ -4,7 +4,6 @@
 #include <cstdint>
 #include <functional>
 #include <fstream>
-#include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -427,11 +426,6 @@ private:
                                     -std::numeric_limits<double>::infinity());
       while (true)
       {
-        if (path.size() == 10000)
-        {
-          std::cerr << "Warning, gradient path is long (i.e >= 10000 steps)"
-                    << std::endl;
-        }
         current_index = GetNextFromGradient(current_index, gradient_vector);
         if (path[current_index] != 0)
         {
@@ -1178,10 +1172,12 @@ public:
       {
         const GradientQuery gradient = GetLocationCoarseGradient4d(
             mutable_location, enable_edge_gradients);
+        // Make sure we haven't run off the edge of the grid
         if (gradient.HasValue())
         {
           const Eigen::Vector4d& grad_vector = gradient.Value();
-          if (grad_vector.norm() > GetResolution() * 0.25) // Sanity check
+          // Make sure the gradient is large enough to be productive
+          if (grad_vector.norm() > GetResolution() * 0.25)
           {
             // Don't step any farther than is needed
             const double step_distance =
@@ -1191,13 +1187,11 @@ public:
           }
           else
           {
-            std::cerr << "Encountered flat gradient - stuck" << std::endl;
             return ProjectedPosition();
           }
         }
         else
         {
-          std::cerr << "Failed to compute gradient - out of SDF?" << std::endl;
           return ProjectedPosition();
         }
       }

--- a/include/voxelized_geometry_tools/signed_distance_field.hpp
+++ b/include/voxelized_geometry_tools/signed_distance_field.hpp
@@ -328,8 +328,6 @@ private:
         = this->GridIndexToLocationInGridFrame(x_idx, y_idx, z_idx);
     const Eigen::Vector4d query_offset
         = grid_frame_query_location - cell_center_location;
-    // We can't catch the easiest case of being at a cell center, since doing so
-    // breaks the ability of Eigen's Autodiff to autodiff this function.
     // Find the best-matching 8 surrounding cell centers
     const std::pair<int64_t, int64_t> x_axis_indices
         = GetAxisInterpolationIndices(

--- a/include/voxelized_geometry_tools/tagged_object_collision_map.hpp
+++ b/include/voxelized_geometry_tools/tagged_object_collision_map.hpp
@@ -16,6 +16,7 @@
 #include <Eigen/Geometry>
 #include <common_robotics_utilities/maybe.hpp>
 #include <common_robotics_utilities/serialization.hpp>
+#include <common_robotics_utilities/utility.hpp>
 #include <common_robotics_utilities/voxel_grid.hpp>
 #include <voxelized_geometry_tools/signed_distance_field.hpp>
 #include <voxelized_geometry_tools/signed_distance_field_generation.hpp>
@@ -302,7 +303,9 @@ public:
 
   topology_computation::TopologicalInvariants ComputeComponentTopology(
       const COMPONENT_TYPES component_types_to_use,
-      const bool connect_across_objects, const bool verbose);
+      const bool connect_across_objects,
+      const common_robotics_utilities::utility::LoggingFunction& logging_fn =
+          common_robotics_utilities::utility::NoOpLoggingFunction());
 
   template<typename ScalarType>
   SignedDistanceField<ScalarType> ExtractSignedDistanceField(

--- a/include/voxelized_geometry_tools/tagged_object_collision_map.hpp
+++ b/include/voxelized_geometry_tools/tagged_object_collision_map.hpp
@@ -304,8 +304,8 @@ public:
   topology_computation::TopologicalInvariants ComputeComponentTopology(
       const COMPONENT_TYPES component_types_to_use,
       const bool connect_across_objects,
-      const common_robotics_utilities::utility::LoggingFunction& logging_fn =
-          common_robotics_utilities::utility::NoOpLoggingFunction());
+      const common_robotics_utilities::utility::LoggingFunction&
+          logging_fn = {});
 
   template<typename ScalarType>
   SignedDistanceField<ScalarType> ExtractSignedDistanceField(

--- a/include/voxelized_geometry_tools/topology_computation.hpp
+++ b/include/voxelized_geometry_tools/topology_computation.hpp
@@ -485,9 +485,12 @@ inline NumberOfHolesAndVoids ComputeHolesAndVoidsInSurface(
       surface_vertices.insert(vertex8);
     }
   }
-  logging_fn(
-      "Surface with " + std::to_string(surface.size()) + " voxels has " +
-      std::to_string(surface_vertices.size()) + " surface vertices");
+  if (logging_fn)
+  {
+    logging_fn(
+        "Surface with " + std::to_string(surface.size()) + " voxels has " +
+        std::to_string(surface_vertices.size()) + " surface vertices");
+  }
   // Iterate through the surface vertices and count the neighbors of each vertex
   int32_t M3 = 0;
   int32_t M5 = 0;
@@ -624,12 +627,15 @@ inline NumberOfHolesAndVoids ComputeHolesAndVoidsInSurface(
   // Compute the number of holes in the surface
   const int32_t raw_number_of_holes = 1 + ((M5 + (2 * M6) - M3) / 8);
   const int32_t number_of_holes = raw_number_of_holes + number_of_voids;
-  logging_fn(
-      "Processed surface with M3 = " + std::to_string(M3) + " M5 = " +
-      std::to_string(M5) + " M6 = " + std::to_string(M6) + " into # holes = " +
-      std::to_string(number_of_holes) + " # of surfaces = " +
-      std::to_string(number_of_surfaces) + " # of voids = " +
-      std::to_string(number_of_voids));
+  if (logging_fn)
+  {
+    logging_fn(
+        "Processed surface with M3 = " + std::to_string(M3) + " M5 = " +
+        std::to_string(M5) + " M6 = " + std::to_string(M6) +
+        " into # holes = " + std::to_string(number_of_holes) +
+        " # of surfaces = " + std::to_string(number_of_surfaces) +
+        " # of voids = " + std::to_string(number_of_voids));
+  }
   return NumberOfHolesAndVoids(number_of_holes, number_of_voids);
 }
 

--- a/src/voxelized_geometry_tools/collision_map.cpp
+++ b/src/voxelized_geometry_tools/collision_map.cpp
@@ -14,6 +14,7 @@
 
 #include <Eigen/Geometry>
 #include <common_robotics_utilities/serialization.hpp>
+#include <common_robotics_utilities/utility.hpp>
 #include <common_robotics_utilities/voxel_grid.hpp>
 #include <common_robotics_utilities/zlib_helpers.hpp>
 #include <voxelized_geometry_tools/topology_computation.hpp>
@@ -459,10 +460,8 @@ uint32_t CollisionMap::UpdateConnectedComponents()
     }
   };
   number_of_components_
-      = topology_computation::ComputeConnectedComponents(*this,
-                                                         are_connected_fn,
-                                                         get_component_fn,
-                                                         mark_component_fn);
+      = topology_computation::ComputeConnectedComponents(
+          *this, are_connected_fn, get_component_fn, mark_component_fn);
   components_valid_ = true;
   return number_of_components_;
 }
@@ -551,7 +550,8 @@ CollisionMap::ExtractEmptyComponentSurfaces() const
 
 topology_computation::TopologicalInvariants
 CollisionMap::ComputeComponentTopology(
-    const COMPONENT_TYPES component_types_to_use, const bool verbose)
+    const COMPONENT_TYPES component_types_to_use,
+    const common_robotics_utilities::utility::LoggingFunction& logging_fn)
 {
   using common_robotics_utilities::voxel_grid::GridIndex;
   UpdateConnectedComponents();
@@ -604,10 +604,8 @@ CollisionMap::ComputeComponentTopology(
     }
     return false;
   };
-  return topology_computation::ComputeComponentTopology(*this,
-                                                        get_component_fn,
-                                                        is_surface_index_fn,
-                                                        verbose);
+  return topology_computation::ComputeComponentTopology(
+      *this, get_component_fn, is_surface_index_fn, logging_fn);
 }
 
 SignedDistanceField<double> CollisionMap::ExtractSignedDistanceFieldDouble(

--- a/src/voxelized_geometry_tools/cuda_voxelization_helpers.cu
+++ b/src/voxelized_geometry_tools/cuda_voxelization_helpers.cu
@@ -284,22 +284,31 @@ public:
         CudaCheckErrors("Failed to get device properties");
         const std::string device_name(device_properties.name);
 
-        logging_fn(
-            "Using CUDA device [" + std::to_string(cuda_device) +
-            "] - Name: [" + device_name + "]");
+        if (logging_fn)
+        {
+          logging_fn(
+              "Using CUDA device [" + std::to_string(cuda_device) +
+              "] - Name: [" + device_name + "]");
+        }
       }
       else
       {
-        logging_fn(
-            "CUDA_DEVICE = " + std::to_string(cuda_device) +
-            " out of range for " + std::to_string(device_count) + " devices");
+        if (logging_fn)
+        {
+          logging_fn(
+              "CUDA_DEVICE = " + std::to_string(cuda_device) +
+              " out of range for " + std::to_string(device_count) + " devices");
+        }
         cuda_device_num_ = -1;
       }
     }
     catch (const std::runtime_error& ex)
     {
-      logging_fn(
-          "Failed to load CUDA runtime and set device: " + ex.what());
+      if (logging_fn)
+      {
+        logging_fn(
+            "Failed to load CUDA runtime and set device: " + ex.what());
+      }
       cuda_device_num_ = -1;
     }
   }

--- a/src/voxelized_geometry_tools/cuda_voxelization_helpers.cu
+++ b/src/voxelized_geometry_tools/cuda_voxelization_helpers.cu
@@ -262,11 +262,12 @@ private:
 class CudaVoxelizationHelperInterface : public DeviceVoxelizationHelperInterface
 {
 public:
-  explicit CudaVoxelizationHelperInterface(
-      const std::map<std::string, int32_t>& options)
+  CudaVoxelizationHelperInterface(
+      const std::map<std::string, int32_t>& options,
+      const LoggingFunction& logging_fn)
   {
-    const int32_t cuda_device =
-        RetrieveOptionOrDefault(options, "CUDA_DEVICE", 0);
+    const int32_t cuda_device = RetrieveOptionOrDefault(
+        options, "CUDA_DEVICE", 0, logging_fn);
     try
     {
       int32_t device_count = 0;
@@ -283,20 +284,22 @@ public:
         CudaCheckErrors("Failed to get device properties");
         const std::string device_name(device_properties.name);
 
-        std::cout << "Using CUDA device [" << cuda_device << "] - Name: ["
-                  << device_name << "]" << std::endl;
+        logging_fn(
+            "Using CUDA device [" + std::to_string(cuda_device) +
+            "] - Name: [" + device_name + "]");
       }
       else
       {
-        std::cerr << "CUDA_DEVICE = " << cuda_device << " out of range for "
-                  << device_count << " devices" << std::endl;
+        logging_fn(
+            "CUDA_DEVICE = " + std::to_string(cuda_device) +
+            " out of range for " + std::to_string(device_count) + " devices");
         cuda_device_num_ = -1;
       }
     }
     catch (const std::runtime_error& ex)
     {
-      std::cerr << "Failed to load CUDA runtime and set device: "
-                << ex.what() << std::endl;
+      logging_fn(
+          "Failed to load CUDA runtime and set device: " + ex.what());
       cuda_device_num_ = -1;
     }
   }
@@ -491,19 +494,18 @@ std::vector<AvailableDevice> GetAvailableDevices()
       available_devices.push_back(AvailableDevice(full_name, device_options));
     }
   }
-  catch (const std::runtime_error& ex)
-  {
-    std::cerr << ex.what() << std::endl;
-  }
+  catch (const std::runtime_error&) {}
 
   return available_devices;
 }
 
 std::unique_ptr<DeviceVoxelizationHelperInterface>
-MakeCudaVoxelizationHelper(const std::map<std::string, int32_t>& options)
+MakeCudaVoxelizationHelper(
+    const std::map<std::string, int32_t>& options,
+    const LoggingFunction& logging_fn)
 {
   return std::unique_ptr<DeviceVoxelizationHelperInterface>(
-      new CudaVoxelizationHelperInterface(options));
+      new CudaVoxelizationHelperInterface(options, logging_fn));
 }
 }  // namespace cuda_helpers
 }  // namespace pointcloud_voxelization

--- a/src/voxelized_geometry_tools/device_pointcloud_voxelization.cpp
+++ b/src/voxelized_geometry_tools/device_pointcloud_voxelization.cpp
@@ -136,20 +136,22 @@ VoxelizerRuntime DevicePointCloudVoxelizer::DoVoxelizePointClouds(
 }
 
 CudaPointCloudVoxelizer::CudaPointCloudVoxelizer(
-    const std::map<std::string, int32_t>& options)
+    const std::map<std::string, int32_t>& options,
+    const LoggingFunction& logging_fn)
 {
   device_name_ = "CudaPointCloudVoxelizer";
   helper_interface_ = std::unique_ptr<DeviceVoxelizationHelperInterface>(
-      cuda_helpers::MakeCudaVoxelizationHelper(options));
+      cuda_helpers::MakeCudaVoxelizationHelper(options, logging_fn));
   EnforceAvailable();
 }
 
 OpenCLPointCloudVoxelizer::OpenCLPointCloudVoxelizer(
-    const std::map<std::string, int32_t>& options)
+    const std::map<std::string, int32_t>& options,
+    const LoggingFunction& logging_fn)
 {
   device_name_ = "OpenCLPointCloudVoxelizer";
   helper_interface_ = std::unique_ptr<DeviceVoxelizationHelperInterface>(
-      opencl_helpers::MakeOpenCLVoxelizationHelper(options));
+      opencl_helpers::MakeOpenCLVoxelizationHelper(options, logging_fn));
   EnforceAvailable();
 }
 }  // namespace pointcloud_voxelization

--- a/src/voxelized_geometry_tools/dummy_cuda_voxelization_helpers.cc
+++ b/src/voxelized_geometry_tools/dummy_cuda_voxelization_helpers.cc
@@ -14,7 +14,8 @@ namespace cuda_helpers
 std::vector<AvailableDevice> GetAvailableDevices() { return {}; }
 
 std::unique_ptr<DeviceVoxelizationHelperInterface>
-MakeCudaVoxelizationHelper(const std::map<std::string, int32_t>&)
+MakeCudaVoxelizationHelper(
+    const std::map<std::string, int32_t>&, const LoggingFunction&)
 {
   return std::unique_ptr<DeviceVoxelizationHelperInterface>();
 }

--- a/src/voxelized_geometry_tools/dummy_opencl_voxelization_helpers.cc
+++ b/src/voxelized_geometry_tools/dummy_opencl_voxelization_helpers.cc
@@ -14,7 +14,8 @@ namespace opencl_helpers
 std::vector<AvailableDevice> GetAvailableDevices() { return {}; }
 
 std::unique_ptr<DeviceVoxelizationHelperInterface>
-MakeOpenCLVoxelizationHelper(const std::map<std::string, int32_t>&)
+MakeOpenCLVoxelizationHelper(
+    const std::map<std::string, int32_t>&, const LoggingFunction&)
 {
   return std::unique_ptr<DeviceVoxelizationHelperInterface>();
 }

--- a/src/voxelized_geometry_tools/opencl_voxelization_helpers.cc
+++ b/src/voxelized_geometry_tools/opencl_voxelization_helpers.cc
@@ -258,10 +258,13 @@ public:
       std::string platform_vendor;
       opencl_platform.getInfo(CL_PLATFORM_VENDOR, &platform_vendor);
 
-      logging_fn(
-          "Using OpenCL Platform [" + std::to_string(platform_index) +
-          "] - Name: [" + platform_name + "], Vendor: [" + platform_vendor +
-          "]");
+      if (logging_fn)
+      {
+        logging_fn(
+            "Using OpenCL Platform [" + std::to_string(platform_index) +
+            "] - Name: [" + platform_name + "], Vendor: [" + platform_vendor +
+            "]");
+      }
 
       std::vector<cl::Device> all_devices;
       opencl_platform.getDevices(CL_DEVICE_TYPE_ALL, &all_devices);
@@ -276,9 +279,12 @@ public:
         std::string device_name;
         opencl_device.getInfo(CL_DEVICE_NAME, &device_name);
 
-        logging_fn(
-            "Using OpenCL Device [" + std::to_string(device_index) +
-            "] - Name: [" + device_name + "]");
+        if (logging_fn)
+        {
+          logging_fn(
+              "Using OpenCL Device [" + std::to_string(device_index) +
+              "] - Name: [" + device_name + "]");
+        }
 
         // Make context + queue
         context_ = std::unique_ptr<cl::Context>(
@@ -302,44 +308,62 @@ public:
         if (raycasting_program_->build({opencl_device}, build_options.c_str())
             != CL_SUCCESS)
         {
-          logging_fn(
-              "Error building raycasting kernel: " +
-              raycasting_program_->getBuildInfo<CL_PROGRAM_BUILD_LOG>(
-                  opencl_device));
+          if (logging_fn)
+          {
+            logging_fn(
+                "Error building raycasting kernel: " +
+                raycasting_program_->getBuildInfo<CL_PROGRAM_BUILD_LOG>(
+                    opencl_device));
+          }
           raycasting_program_.reset();
         }
         if (filter_program_->build({opencl_device}, build_options.c_str())
             != CL_SUCCESS)
         {
-          logging_fn(
-              "Error building filter kernel: " +
-              filter_program_->getBuildInfo<CL_PROGRAM_BUILD_LOG>(
-                  opencl_device));
+          if (logging_fn)
+          {
+            logging_fn(
+                "Error building filter kernel: " +
+                filter_program_->getBuildInfo<CL_PROGRAM_BUILD_LOG>(
+                    opencl_device));
+          }
           filter_program_.reset();
         }
       }
       else if (all_devices.size() > 0)
       {
-        logging_fn(
-            "OPENCL_DEVICE_INDEX = " + std::to_string(device_index) +
-            " out of range for " + std::to_string(all_devices.size()) +
-            " devices");
+        if (logging_fn)
+        {
+          logging_fn(
+              "OPENCL_DEVICE_INDEX = " + std::to_string(device_index) +
+              " out of range for " + std::to_string(all_devices.size()) +
+              " devices");
+        }
       }
       else
       {
-        logging_fn("No OpenCL device available");
+        if (logging_fn)
+        {
+          logging_fn("No OpenCL device available");
+        }
       }
     }
     else if (all_platforms.size() > 0)
     {
-      logging_fn(
-          "OPENCL_PLATFORM_INDEX = " + std::to_string(platform_index) +
-          " out of range for " + std::to_string(all_platforms.size()) +
-          " platforms");
+      if (logging_fn)
+      {
+        logging_fn(
+            "OPENCL_PLATFORM_INDEX = " + std::to_string(platform_index) +
+            " out of range for " + std::to_string(all_platforms.size()) +
+            " platforms");
+      }
     }
     else
     {
-      logging_fn("No OpenCL platform available");
+      if (logging_fn)
+      {
+        logging_fn("No OpenCL platform available");
+      }
     }
   }
 

--- a/src/voxelized_geometry_tools/pointcloud_voxelization.cpp
+++ b/src/voxelized_geometry_tools/pointcloud_voxelization.cpp
@@ -87,31 +87,46 @@ MakeBestAvailablePointCloudVoxelizer(
   // directly construct the desired voxelizer.
   try
   {
-    logging_fn("Trying to construct CUDA PointCloud Voxelizer...");
+    if (logging_fn)
+    {
+      logging_fn("Trying to construct CUDA PointCloud Voxelizer...");
+    }
     return std::unique_ptr<PointCloudVoxelizationInterface>(
         new CudaPointCloudVoxelizer(device_options, logging_fn));
   }
-  catch (std::runtime_error&)
+  catch (const std::runtime_error&)
   {
-    logging_fn("CUDA PointCloud Voxelizer is not available");
+    if (logging_fn)
+    {
+      logging_fn("CUDA PointCloud Voxelizer is not available");
+    }
   }
   try
   {
-    logging_fn("Trying to construct OpenCL PointCloud Voxelizer...");
+    if (logging_fn)
+    {
+      logging_fn("Trying to construct OpenCL PointCloud Voxelizer...");
+    }
     return std::unique_ptr<PointCloudVoxelizationInterface>(
         new OpenCLPointCloudVoxelizer(device_options, logging_fn));
   }
-  catch (std::runtime_error&)
+  catch (const std::runtime_error&)
   {
-    logging_fn("OpenCL PointCloud Voxelizer is not available");
+    if (logging_fn)
+    {
+      logging_fn("OpenCL PointCloud Voxelizer is not available");
+    }
   }
   try
   {
-    logging_fn("Trying to construct CPU PointCloud Voxelizer...");
+    if (logging_fn)
+    {
+      logging_fn("Trying to construct CPU PointCloud Voxelizer...");
+    }
     return std::unique_ptr<PointCloudVoxelizationInterface>(
         new CpuPointCloudVoxelizer());
   }
-  catch (std::runtime_error&)
+  catch (const std::runtime_error&)
   {
     throw std::runtime_error("No PointCloud Voxelizers available");
   }

--- a/src/voxelized_geometry_tools/pointcloud_voxelization.cpp
+++ b/src/voxelized_geometry_tools/pointcloud_voxelization.cpp
@@ -38,14 +38,14 @@ std::vector<AvailableBackend> GetAvailableBackends()
   return available_backends;
 }
 
-std::unique_ptr<PointCloudVoxelizationInterface>
-MakePointCloudVoxelizer(
+std::unique_ptr<PointCloudVoxelizationInterface> MakePointCloudVoxelizer(
     const BackendOptions backend_option,
-    const std::map<std::string, int32_t>& device_options)
+    const std::map<std::string, int32_t>& device_options,
+    const LoggingFunction& logging_fn)
 {
   if (backend_option == BackendOptions::BEST_AVAILABLE)
   {
-    return MakeBestAvailablePointCloudVoxelizer(device_options);
+    return MakeBestAvailablePointCloudVoxelizer(device_options, logging_fn);
   }
   else if (backend_option == BackendOptions::CPU)
   {
@@ -55,12 +55,12 @@ MakePointCloudVoxelizer(
   else if (backend_option == BackendOptions::OPENCL)
   {
     return std::unique_ptr<PointCloudVoxelizationInterface>(
-        new OpenCLPointCloudVoxelizer(device_options));
+        new OpenCLPointCloudVoxelizer(device_options, logging_fn));
   }
   else if (backend_option == BackendOptions::CUDA)
   {
     return std::unique_ptr<PointCloudVoxelizationInterface>(
-        new CudaPointCloudVoxelizer(device_options));
+        new CudaPointCloudVoxelizer(device_options, logging_fn));
   }
   else
   {
@@ -68,16 +68,17 @@ MakePointCloudVoxelizer(
   }
 }
 
-std::unique_ptr<PointCloudVoxelizationInterface>
-MakePointCloudVoxelizer(const AvailableBackend& backend)
+std::unique_ptr<PointCloudVoxelizationInterface> MakePointCloudVoxelizer(
+    const AvailableBackend& backend, const LoggingFunction& logging_fn)
 {
   return MakePointCloudVoxelizer(
-      backend.BackendOption(), backend.DeviceOptions());
+      backend.BackendOption(), backend.DeviceOptions(), logging_fn);
 }
 
 std::unique_ptr<PointCloudVoxelizationInterface>
 MakeBestAvailablePointCloudVoxelizer(
-    const std::map<std::string, int32_t>& device_options)
+    const std::map<std::string, int32_t>& device_options,
+    const LoggingFunction& logging_fn)
 {
   // Since not all voxelizers will be available on all platforms, we try them
   // in order of preference. If available (i.e. on NVIDIA platforms), CUDA is
@@ -86,27 +87,27 @@ MakeBestAvailablePointCloudVoxelizer(
   // directly construct the desired voxelizer.
   try
   {
-    std::cout << "Trying CUDA PointCloud Voxelizer..." << std::endl;
+    logging_fn("Trying to construct CUDA PointCloud Voxelizer...");
     return std::unique_ptr<PointCloudVoxelizationInterface>(
-        new CudaPointCloudVoxelizer(device_options));
+        new CudaPointCloudVoxelizer(device_options, logging_fn));
   }
   catch (std::runtime_error&)
   {
-    std::cerr << "CUDA PointCloud Voxelizer is not available" << std::endl;
+    logging_fn("CUDA PointCloud Voxelizer is not available");
   }
   try
   {
-    std::cout << "Trying OpenCL PointCloud Voxelizer..." << std::endl;
+    logging_fn("Trying to construct OpenCL PointCloud Voxelizer...");
     return std::unique_ptr<PointCloudVoxelizationInterface>(
-        new OpenCLPointCloudVoxelizer(device_options));
+        new OpenCLPointCloudVoxelizer(device_options, logging_fn));
   }
   catch (std::runtime_error&)
   {
-    std::cerr << "OpenCL PointCloud Voxelizer is not available" << std::endl;
+    logging_fn("OpenCL PointCloud Voxelizer is not available");
   }
   try
   {
-    std::cout << "Trying CPU PointCloud Voxelizer..." << std::endl;
+    logging_fn("Trying to construct CPU PointCloud Voxelizer...");
     return std::unique_ptr<PointCloudVoxelizationInterface>(
         new CpuPointCloudVoxelizer());
   }

--- a/src/voxelized_geometry_tools/tagged_object_collision_map.cpp
+++ b/src/voxelized_geometry_tools/tagged_object_collision_map.cpp
@@ -14,6 +14,7 @@
 
 #include <Eigen/Geometry>
 #include <common_robotics_utilities/serialization.hpp>
+#include <common_robotics_utilities/utility.hpp>
 #include <common_robotics_utilities/voxel_grid.hpp>
 #include <common_robotics_utilities/zlib_helpers.hpp>
 #include <voxelized_geometry_tools/topology_computation.hpp>
@@ -508,7 +509,8 @@ TaggedObjectCollisionMap::ExtractEmptyComponentSurfaces() const
 topology_computation::TopologicalInvariants
 TaggedObjectCollisionMap::ComputeComponentTopology(
     const COMPONENT_TYPES component_types_to_use,
-    const bool connect_across_objects, const bool verbose)
+    const bool connect_across_objects,
+    const common_robotics_utilities::utility::LoggingFunction& logging_fn)
 {
   using common_robotics_utilities::voxel_grid::GridIndex;
   UpdateConnectedComponents(connect_across_objects);
@@ -562,10 +564,8 @@ TaggedObjectCollisionMap::ComputeComponentTopology(
     }
     return false;
   };
-  return topology_computation::ComputeComponentTopology(*this,
-                                                        get_component_fn,
-                                                        is_surface_index_fn,
-                                                        verbose);
+  return topology_computation::ComputeComponentTopology(
+      *this, get_component_fn, is_surface_index_fn, logging_fn);
 }
 
 SignedDistanceField<double>
@@ -728,10 +728,8 @@ uint32_t TaggedObjectCollisionMap::UpdateConnectedComponents(
     }
   };
   number_of_components_
-      = topology_computation::ComputeConnectedComponents(*this,
-                                                         are_connected_fn,
-                                                         get_component_fn,
-                                                         mark_component_fn);
+      = topology_computation::ComputeConnectedComponents(
+          *this, are_connected_fn, get_component_fn, mark_component_fn);
   components_valid_ = true;
   return number_of_components_;
 }
@@ -829,10 +827,8 @@ uint32_t TaggedObjectCollisionMap::UpdateSpatialSegments(
     }
   };
   number_of_spatial_segments_
-      = topology_computation::ComputeConnectedComponents(*this,
-                                                         are_connected_fn,
-                                                         get_component_fn,
-                                                         mark_component_fn);
+      = topology_computation::ComputeConnectedComponents(
+          *this, are_connected_fn, get_component_fn, mark_component_fn);
   spatial_segments_valid_ = true;
   return number_of_spatial_segments_;
 }

--- a/test/pointcloud_voxelization_test.cpp
+++ b/test/pointcloud_voxelization_test.cpp
@@ -232,6 +232,8 @@ GTEST_TEST(PointCloudVoxelizationTest, Test)
   // Run all available voxelizers
   const auto available_backends =
       pointcloud_voxelization::GetAvailableBackends();
+  const pointcloud_voxelization::LoggingFunction logging_fn =
+      [] (const std::string& msg) { std::cout << msg << std::endl; };
 
   for (size_t idx = 0; idx < available_backends.size(); idx++)
   {
@@ -239,8 +241,8 @@ GTEST_TEST(PointCloudVoxelizationTest, Test)
     std::cout << "Trying voxelizer [" << idx << "] "
               << available_backend.DeviceName() << std::endl;
 
-    auto voxelizer =
-        pointcloud_voxelization::MakePointCloudVoxelizer(available_backend);
+    auto voxelizer = pointcloud_voxelization::MakePointCloudVoxelizer(
+        available_backend, logging_fn);
 
     const auto empty_voxelized = voxelizer->VoxelizePointClouds(
         static_environment, step_size_multiplier, filter_options, {});

--- a/test/pointcloud_voxelization_test.cpp
+++ b/test/pointcloud_voxelization_test.cpp
@@ -253,6 +253,22 @@ GTEST_TEST(PointCloudVoxelizationTest, Test)
         {cam1_cloud, cam2_cloud, cam3_cloud});
     check_voxelization(voxelized);
   }
+
+  // Ensure all voxelizers support null logging functions
+  for (size_t idx = 0; idx < available_backends.size(); idx++)
+  {
+    const auto& available_backend = available_backends.at(idx);
+    std::cout << "Trying voxelizer [" << idx << "] "
+              << available_backend.DeviceName() << std::endl;
+
+    ASSERT_NO_THROW(pointcloud_voxelization::MakePointCloudVoxelizer(
+        available_backend, {}));
+  }
+
+  // Ensure that MakeBestAvailablePointCloudVoxelizer works, with empty device
+  // options and null logging function.
+  ASSERT_NO_THROW(
+      pointcloud_voxelization::MakeBestAvailablePointCloudVoxelizer({}, {}));
 }
 }  // namespace
 }  // namespace voxelized_geometry_tools


### PR DESCRIPTION
Replaces existing `iostream` (`std::cout`/`std::cerr`) logging with configurable logging functions shared with `common_robotics_utilities`.

Requires [CRU #54](https://github.com/calderpg/common_robotics_utilities/pull/54) land before merging.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/voxelized_geometry_tools/38)
<!-- Reviewable:end -->
