### PR TITLE
Replace raw omp parallel for pragmas, make some CPU parallel operations optional

### DIFF
--- a/example/pointcloud_voxelization.cpp
+++ b/example/pointcloud_voxelization.cpp
@@ -295,7 +295,7 @@ void test_pointcloud_voxelization(
   {
     std::cout << "Trying CPU PointCloud Voxelizer..." << std::endl;
     std::unique_ptr<PointCloudVoxelizationInterface> voxelizer(
-        new CpuPointCloudVoxelizer());
+        new CpuPointCloudVoxelizer(options));
     const auto cpu_voxelized = voxelizer->VoxelizePointClouds(
         static_environment, step_size_multiplier, filter_options,
         {cam1_cloud, cam2_cloud});

--- a/include/voxelized_geometry_tools/cpu_pointcloud_voxelization.hpp
+++ b/include/voxelized_geometry_tools/cpu_pointcloud_voxelization.hpp
@@ -13,7 +13,8 @@ namespace pointcloud_voxelization
 /// CPU-based (OpenMP) implementation of pointcloud voxelizer.
 class CpuPointCloudVoxelizer : public PointCloudVoxelizationInterface {
 public:
-  CpuPointCloudVoxelizer() {}
+  explicit CpuPointCloudVoxelizer(
+      const std::map<std::string, int32_t>& options);
 
 private:
   VoxelizerRuntime DoVoxelizePointClouds(
@@ -21,6 +22,8 @@ private:
       const PointCloudVoxelizationFilterOptions& filter_options,
       const std::vector<PointCloudWrapperSharedPtr>& pointclouds,
       CollisionMap& output_environment) const override;
+
+  bool use_parallel_ = true;
 };
 }  // namespace pointcloud_voxelization
 }  // namespace voxelized_geometry_tools

--- a/include/voxelized_geometry_tools/cpu_pointcloud_voxelization.hpp
+++ b/include/voxelized_geometry_tools/cpu_pointcloud_voxelization.hpp
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include <voxelized_geometry_tools/collision_map.hpp>
+#include <voxelized_geometry_tools/device_voxelization_interface.hpp>
 #include <voxelized_geometry_tools/pointcloud_voxelization_interface.hpp>
 
 namespace voxelized_geometry_tools
@@ -13,8 +14,9 @@ namespace pointcloud_voxelization
 /// CPU-based (OpenMP) implementation of pointcloud voxelizer.
 class CpuPointCloudVoxelizer : public PointCloudVoxelizationInterface {
 public:
-  explicit CpuPointCloudVoxelizer(
-      const std::map<std::string, int32_t>& options);
+  CpuPointCloudVoxelizer(
+      const std::map<std::string, int32_t>& options,
+      const LoggingFunction& logging_fn = {});
 
 private:
   VoxelizerRuntime DoVoxelizePointClouds(

--- a/include/voxelized_geometry_tools/mesh_rasterizer.hpp
+++ b/include/voxelized_geometry_tools/mesh_rasterizer.hpp
@@ -31,7 +31,8 @@ void RasterizeMesh(
     const std::vector<Eigen::Vector3d>& vertices,
     const std::vector<Eigen::Vector3i>& triangles,
     voxelized_geometry_tools::CollisionMap& collision_map,
-    const bool enforce_collision_map_contains_mesh = true);
+    const bool enforce_collision_map_contains_mesh = true,
+    const bool use_parallel = true);
 
 /// This sets all voxels intersected by the provided mesh to filled. Note
 /// that it sets voxels filled regardless of whether or not the voxel cell
@@ -40,6 +41,6 @@ void RasterizeMesh(
 voxelized_geometry_tools::CollisionMap RasterizeMeshIntoCollisionMap(
     const std::vector<Eigen::Vector3d>& vertices,
     const std::vector<Eigen::Vector3i>& triangles,
-    const double resolution);
+    const double resolution, const bool use_parallel = true);
 }  // namespace voxelized_geometry_tools
 

--- a/src/voxelized_geometry_tools/cpu_pointcloud_voxelization.cpp
+++ b/src/voxelized_geometry_tools/cpu_pointcloud_voxelization.cpp
@@ -206,10 +206,11 @@ void CombineAndFilterGrids(
 }  // namespace
 
 CpuPointCloudVoxelizer::CpuPointCloudVoxelizer(
-    const std::map<std::string, int32_t>& options)
+    const std::map<std::string, int32_t>& options,
+    const LoggingFunction& logging_fn)
 {
   const int32_t cpu_parallelize =
-      RetrieveOptionOrDefault(options, "CPU_PARALLELIZE", 1);
+      RetrieveOptionOrDefault(options, "CPU_PARALLELIZE", 1, logging_fn);
   use_parallel_ = static_cast<bool>(cpu_parallelize);
 }
 

--- a/src/voxelized_geometry_tools/cuda_voxelization_helpers.cu
+++ b/src/voxelized_geometry_tools/cuda_voxelization_helpers.cu
@@ -307,7 +307,8 @@ public:
       if (logging_fn)
       {
         logging_fn(
-            "Failed to load CUDA runtime and set device: " + ex.what());
+            "Failed to load CUDA runtime and set device: " +
+            std::string(ex.what()));
       }
       cuda_device_num_ = -1;
     }

--- a/src/voxelized_geometry_tools/device_pointcloud_voxelization.cpp
+++ b/src/voxelized_geometry_tools/device_pointcloud_voxelization.cpp
@@ -1,9 +1,5 @@
 #include <voxelized_geometry_tools/device_pointcloud_voxelization.hpp>
 
-#if defined(_OPENMP)
-#include <omp.h>
-#endif
-
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -13,6 +9,7 @@
 #include <vector>
 
 #include <Eigen/Geometry>
+#include <common_robotics_utilities/openmp_helpers.hpp>
 #include <voxelized_geometry_tools/collision_map.hpp>
 #include <voxelized_geometry_tools/cuda_voxelization_helpers.h>
 #include <voxelized_geometry_tools/opencl_voxelization_helpers.h>
@@ -66,9 +63,7 @@ VoxelizerRuntime DevicePointCloudVoxelizer::DoVoxelizePointClouds(
       static_cast<int32_t>(static_environment.GetNumZCells());
 
   // Do raycasting of the pointclouds
-#if defined(_OPENMP)
-#pragma omp parallel for
-#endif
+  CRU_OMP_PARALLEL_FOR
   for (size_t idx = 0; idx < pointclouds.size(); idx++)
   {
     const PointCloudWrapperSharedPtr& pointcloud = pointclouds.at(idx);

--- a/src/voxelized_geometry_tools/pointcloud_voxelization.cpp
+++ b/src/voxelized_geometry_tools/pointcloud_voxelization.cpp
@@ -33,7 +33,10 @@ std::vector<AvailableBackend> GetAvailableBackends()
   }
 
   available_backends.push_back(AvailableBackend(
-      "CPU/OpenMP", {}, BackendOptions::CPU));
+      "CPU/OpenMP", {{"CPU_PARALLELIZE", 1}}, BackendOptions::CPU));
+
+  available_backends.push_back(AvailableBackend(
+      "CPU/OpenMP", {{"CPU_PARALLELIZE", 0}}, BackendOptions::CPU));
 
   return available_backends;
 }
@@ -50,7 +53,7 @@ std::unique_ptr<PointCloudVoxelizationInterface> MakePointCloudVoxelizer(
   else if (backend_option == BackendOptions::CPU)
   {
     return std::unique_ptr<PointCloudVoxelizationInterface>(
-        new CpuPointCloudVoxelizer());
+        new CpuPointCloudVoxelizer(device_options));
   }
   else if (backend_option == BackendOptions::OPENCL)
   {
@@ -124,7 +127,7 @@ MakeBestAvailablePointCloudVoxelizer(
       logging_fn("Trying to construct CPU PointCloud Voxelizer...");
     }
     return std::unique_ptr<PointCloudVoxelizationInterface>(
-        new CpuPointCloudVoxelizer());
+        new CpuPointCloudVoxelizer(device_options));
   }
   catch (const std::runtime_error&)
   {

--- a/src/voxelized_geometry_tools/pointcloud_voxelization.cpp
+++ b/src/voxelized_geometry_tools/pointcloud_voxelization.cpp
@@ -33,10 +33,10 @@ std::vector<AvailableBackend> GetAvailableBackends()
   }
 
   available_backends.push_back(AvailableBackend(
-      "CPU/OpenMP", {{"CPU_PARALLELIZE", 1}}, BackendOptions::CPU));
+      "CPU/OpenMP (parallel)", {{"CPU_PARALLELIZE", 1}}, BackendOptions::CPU));
 
   available_backends.push_back(AvailableBackend(
-      "CPU/OpenMP", {{"CPU_PARALLELIZE", 0}}, BackendOptions::CPU));
+      "CPU/OpenMP (serial)", {{"CPU_PARALLELIZE", 0}}, BackendOptions::CPU));
 
   return available_backends;
 }
@@ -53,7 +53,7 @@ std::unique_ptr<PointCloudVoxelizationInterface> MakePointCloudVoxelizer(
   else if (backend_option == BackendOptions::CPU)
   {
     return std::unique_ptr<PointCloudVoxelizationInterface>(
-        new CpuPointCloudVoxelizer(device_options));
+        new CpuPointCloudVoxelizer(device_options, logging_fn));
   }
   else if (backend_option == BackendOptions::OPENCL)
   {
@@ -127,7 +127,7 @@ MakeBestAvailablePointCloudVoxelizer(
       logging_fn("Trying to construct CPU PointCloud Voxelizer...");
     }
     return std::unique_ptr<PointCloudVoxelizationInterface>(
-        new CpuPointCloudVoxelizer(device_options));
+        new CpuPointCloudVoxelizer(device_options, logging_fn));
   }
   catch (const std::runtime_error&)
   {

--- a/src/voxelized_geometry_tools/signed_distance_field_generation.cpp
+++ b/src/voxelized_geometry_tools/signed_distance_field_generation.cpp
@@ -1,9 +1,5 @@
 #include <voxelized_geometry_tools/signed_distance_field_generation.hpp>
 
-#if defined(_OPENMP)
-#include <omp.h>
-#endif
-
 #include <cmath>
 #include <cstdint>
 #include <functional>
@@ -322,9 +318,7 @@ DistanceField BuildDistanceFieldParallel(
   int32_t initial_update_direction = GetDirectionNumber(0, 0, 0);
   // Mark all provided points with distance zero and add to the bucket queues
   // points MUST NOT CONTAIN DUPLICATE ENTRIES!
-#if defined(_OPENMP)
-#pragma omp parallel for
-#endif
+  CRU_OMP_PARALLEL_FOR
   for (size_t index = 0; index < points.size(); index++)
   {
     const GridIndex& current_index = points[index];
@@ -356,9 +350,7 @@ DistanceField BuildDistanceFieldParallel(
            < static_cast<int32_t>(bucket_queues.NumQueues());
        current_distance_square++)
   {
-#if defined(_OPENMP)
-#pragma omp parallel for
-#endif
+    CRU_OMP_PARALLEL_FOR
     for (size_t idx = 0; idx < bucket_queues.Size(current_distance_square);
          idx++)
     {


### PR DESCRIPTION
Replaces raw OpenMP pragma use with new macros defined in `common_robotics_utilities`, and makes some existing OpenMP-parallelized operations allow for optional parallelism.

Requires [CRU #55](https://github.com/calderpg/common_robotics_utilities/pull/55) to land before merging, and requires a rebase after #38 lands.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/voxelized_geometry_tools/39)
<!-- Reviewable:end -->
