### PR TITLE
Work around dangling reference error

### DIFF
--- a/include/voxelized_geometry_tools/signed_distance_field.hpp
+++ b/include/voxelized_geometry_tools/signed_distance_field.hpp
@@ -386,8 +386,9 @@ private:
   {
     // First, check if we've already found the local extrema for the current
     // cell
-    const Eigen::Vector3d& stored
-        = watershed_map.GetIndexImmutable(x_index, y_index, z_index).Value();
+    const auto starting_index_query
+        = watershed_map.GetIndexImmutable(x_index, y_index, z_index);
+    const Eigen::Vector3d& stored = starting_index_query.Value();
     if (stored.x() != -std::numeric_limits<double>::infinity()
         && stored.y() != -std::numeric_limits<double>::infinity()
         && stored.z() != -std::numeric_limits<double>::infinity())
@@ -442,8 +443,9 @@ private:
         }
         path[current_index] = 1;
         // Check if the new index has already been checked
-        const Eigen::Vector3d& new_stored
-            = watershed_map.GetIndexImmutable(current_index).Value();
+        const auto current_index_query
+            = watershed_map.GetIndexImmutable(current_index);
+        const Eigen::Vector3d& new_stored = current_index_query.Value();
         if (new_stored.x() != -std::numeric_limits<double>::infinity()
             && new_stored.y() != -std::numeric_limits<double>::infinity()
             && new_stored.z() != -std::numeric_limits<double>::infinity())

--- a/include/voxelized_geometry_tools/tagged_object_collision_map.hpp
+++ b/include/voxelized_geometry_tools/tagged_object_collision_map.hpp
@@ -387,8 +387,8 @@ public:
       {
         for (int64_t z_index = 0; z_index < GetNumZCells(); z_index++)
         {
-          const TaggedObjectCollisionCell& cell
-              = GetIndexImmutable(x_index, y_index, z_index).Value();
+          const auto query = GetIndexImmutable(x_index, y_index, z_index);
+          const TaggedObjectCollisionCell& cell = query.Value();
           const uint32_t cell_object_id = cell.ObjectId();
           if (cell_object_id > 0)
           {

--- a/src/voxelized_geometry_tools/collision_map.cpp
+++ b/src/voxelized_geometry_tools/collision_map.cpp
@@ -489,7 +489,8 @@ CollisionMap::ExtractComponentSurfaces(
   const std::function<bool(const GridIndex&)> is_surface_index_fn
       = [&] (const GridIndex& index)
   {
-    const CollisionCell& current_cell = GetIndexImmutable(index).Value();
+    const auto query = GetIndexImmutable(index);
+    const CollisionCell& current_cell = query.Value();
     if (current_cell.Occupancy() > 0.5)
     {
       if ((component_types_to_extract & FILLED_COMPONENTS) > 0x00)
@@ -571,7 +572,8 @@ CollisionMap::ComputeComponentTopology(
   const std::function<bool(const GridIndex&)> is_surface_index_fn
       = [&] (const GridIndex& index)
   {
-    const CollisionCell& current_cell = GetIndexImmutable(index).Value();
+    const auto query = GetIndexImmutable(index);
+    const CollisionCell& current_cell = query.Value();
     if (current_cell.Occupancy() > 0.5)
     {
       if ((component_types_to_use & FILLED_COMPONENTS) > 0x00)

--- a/src/voxelized_geometry_tools/tagged_object_collision_map.cpp
+++ b/src/voxelized_geometry_tools/tagged_object_collision_map.cpp
@@ -446,8 +446,8 @@ TaggedObjectCollisionMap::ExtractComponentSurfaces(
   const std::function<bool(const GridIndex&)> is_surface_index_fn
       = [&] (const GridIndex& index)
   {
-    const TaggedObjectCollisionCell& current_cell
-        = GetIndexImmutable(index).Value();
+    const auto query = GetIndexImmutable(index);
+    const TaggedObjectCollisionCell& current_cell = query.Value();
     if (current_cell.Occupancy() > 0.5)
     {
       if ((component_types_to_extract & FILLED_COMPONENTS) > 0x00)
@@ -529,8 +529,8 @@ TaggedObjectCollisionMap::ComputeComponentTopology(
   const std::function<bool(const GridIndex&)> is_surface_index_fn
       = [&] (const GridIndex& index)
   {
-    const TaggedObjectCollisionCell& current_cell
-        = GetIndexImmutable(index).Value();
+    const auto query = GetIndexImmutable(index);
+    const TaggedObjectCollisionCell& current_cell = query.Value();
     if (current_cell.Occupancy() > 0.5)
     {
       if ((component_types_to_use & FILLED_COMPONENTS) > 0x00)


### PR DESCRIPTION
Newer g++ on 24.04 incorrectly thinks references to voxel elements returned via voxel grid queries are references to temporaries, and produces a `dangling-references` error. Instead of disabling the error for these cases, we work around it by keeping the query result in scope.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/calderpg/voxelized_geometry_tools/52)
<!-- Reviewable:end -->
